### PR TITLE
fix: using LogosResult on send

### DIFF
--- a/delivery_module_interface.h
+++ b/delivery_module_interface.h
@@ -2,7 +2,7 @@
 
 #include <QtCore/QObject>
 #include "interface.h"
-#include "QExpected.h"
+#include "logos_types.h"
 
 class DeliveryModuleInterface : public PluginInterface
 {
@@ -11,7 +11,7 @@ public:
     Q_INVOKABLE virtual bool createNode(const QString &cfg) = 0;
     Q_INVOKABLE virtual bool start() = 0;
     Q_INVOKABLE virtual bool stop() = 0;
-    Q_INVOKABLE virtual QExpected<QString> send(const QString &contentTopic, const QString &payload) = 0;
+    Q_INVOKABLE virtual LogosResult send(const QString &contentTopic, const QString &payload) = 0;
     Q_INVOKABLE virtual bool subscribe(const QString &contentTopic) = 0;
     Q_INVOKABLE virtual bool unsubscribe(const QString &contentTopic) = 0;
     Q_INVOKABLE virtual QString getAvailableNodeInfoIDs() = 0;

--- a/delivery_module_plugin.cpp
+++ b/delivery_module_plugin.cpp
@@ -239,26 +239,26 @@ bool DeliveryModulePlugin::stop()
     qDebug() << "DeliveryModulePlugin: Messaging stop completed with success: true";
     return true;
 }
-QExpected<QString> DeliveryModulePlugin::send(const QString &contentTopic, const QString &payload)
+LogosResult DeliveryModulePlugin::send(const QString &contentTopic, const QString &payload)
 {
     qDebug() << "DeliveryModulePlugin::send called with contentTopic:" << contentTopic;
     qDebug() << "DeliveryModulePlugin::send payload:" << payload;
-    
+
     if (!deliveryCtx) {
         qWarning() << "DeliveryModulePlugin: Cannot send message - context not initialized. Call createNode first.";
-        return QExpected<QString>::err("Context not initialized");
+        return {false, QVariant(), QStringLiteral("Context not initialized")};
     }
-    
+
     // Construct JSON message according to logosdelivery_send API
     // The payload should be base64-encoded as per the API spec
     QJsonObject messageObj;
     messageObj["contentTopic"] = contentTopic;
     messageObj["payload"] = QString::fromUtf8(payload.toUtf8().toBase64());
     messageObj["ephemeral"] = false;
-    
+
     QJsonDocument doc(messageObj);
     QByteArray messageJson = doc.toJson(QJsonDocument::Compact);
-    
+
     auto outcome = callApiRetValue<QString>(
         "send",
         CALLBACK_TIMEOUT,
@@ -266,12 +266,12 @@ QExpected<QString> DeliveryModulePlugin::send(const QString &contentTopic, const
 
     if (outcome.isErr()) {
         qWarning() << "DeliveryModulePlugin: Send failed for topic:" << contentTopic << ", reason:" << outcome.error();
-        return QExpected<QString>::err(outcome.error());
+        return {false, QVariant(), outcome.error()};
     }
 
     const QString responseMessage = outcome.value();
     qDebug() << "DeliveryModulePlugin: Send initiated for topic:" << contentTopic << ", with success: true";
-    return QExpected<QString>::ok(responseMessage);
+    return {true, responseMessage};
 }
 
 bool DeliveryModulePlugin::subscribe(const QString &contentTopic)

--- a/delivery_module_plugin.h
+++ b/delivery_module_plugin.h
@@ -169,7 +169,7 @@ public:
      *                bytes and base64-encoded before crossing the FFI boundary.
      * @return Success with request id, or error details.
      */
-    Q_INVOKABLE QExpected<QString> send(const QString &contentTopic, const QString &payload) override;
+    Q_INVOKABLE LogosResult send(const QString &contentTopic, const QString &payload) override;
 
     /**
      * @brief Subscribes to the supplied content topic.

--- a/examples/simple.cpp
+++ b/examples/simple.cpp
@@ -143,10 +143,10 @@ int main(int argc, char *argv[])
             break;
         } else if (!input.empty()) {
             auto result = delivery->send(contentTopicOfInterest, QString::fromStdString(input));
-            if (!result.isErr())
-                qDebug() << "Send result:" << result.value();
+            if (result.success)
+                qDebug() << "Send result:" << result.getString();
             else
-                qDebug() << "Send failed";
+                qDebug() << "Send failed:" << result.getError();
         }
     }
 


### PR DESCRIPTION
`LogosResult` is supported in `logos-cpp-sdk` for this purpose. 

It was failing with the following error:

```
[LOGOS_HOST "delivery_module" ]: "ModuleProxy: Found matching method at index 8"
[LOGOS_HOST "delivery_module" ]: "ModuleProxy: Method signature: \"send(QString,QString)\""
[LOGOS_HOST "delivery_module" ]: "ModuleProxy: Parameter types:"
[LOGOS_HOST "delivery_module" ]: "  Param 0 : QString"
[LOGOS_HOST "delivery_module" ]: "  Param 1 : QString"
[LOGOS_HOST "delivery_module" ]: "ModuleProxy: Unsupported return type: QExpected<QString> for method: \"send\""
``` 