### PR TITLE
chore: bump logos-delivery to 509c8755 (postgres support)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -167,11 +167,11 @@
         "zerokit": "zerokit"
       },
       "locked": {
-        "lastModified": 1776170869,
-        "narHash": "sha256-bmudtYQv702S7dt7WLV+MYAgNtSE7539Kw+qU7NvCyA=",
+        "lastModified": 1776262372,
+        "narHash": "sha256-hpmgOZPy2o4fWZIHSYQmpL6msOiepnajcXHjNNS0j+w=",
         "ref": "refs/heads/master",
-        "rev": "ecd3758580015a3fb80bb0461d736a8b4c539c64",
-        "revCount": 2299,
+        "rev": "509c8755336948b5759310555fc0db9ffc895ada",
+        "revCount": 2300,
         "submodules": true,
         "type": "git",
         "url": "https://github.com/logos-messaging/logos-delivery"


### PR DESCRIPTION
## Summary

Bumps the `logos-delivery` flake input to latest master commit `509c8755`.

## Changes

- Updated `flake.lock`: `logos-delivery` pinned to `509c8755336948b5759310555fc0db9ffc895ada` (2026-04-15)

## Postgres support

This commit of `logos-delivery` is compiled with `--define:postgres`, enabling postgres support. Postgres support has runtime linkage into `liblogosdelivery.dylib` (with dlopen+dlsym); `libpq` is bundled alongside the module artifacts at runtime via the existing `postInstall` hook.

**Verified artifacts in `result/lib/`:**
- `delivery_module_plugin.dylib`
- `liblogosdelivery.dylib`
- `libpq.dylib` / `libpq.5.dylib`
- `librln.dylib` (new — ZeroKit RLN dependency)

Co-Authored-By: Oz <oz-agent@warp.dev>

---
[Warp conversation](https://app.warp.dev/conversation/b3d52fb9-5072-451a-ac69-daf31e17ff74)