### PR TITLE
fix: return QVariant(JSON) from Q_INVOKABLE methods instead of LogosResult

### DIFF
--- a/src/delivery_module_interface.h
+++ b/src/delivery_module_interface.h
@@ -1,22 +1,22 @@
 #pragma once
 
 #include <QtCore/QObject>
+#include <QtCore/QVariant>
 #include "interface.h"
-#include "logos_types.h"
 
 class DeliveryModuleInterface : public PluginInterface
 {
 public:
     virtual ~DeliveryModuleInterface() {}
-    Q_INVOKABLE virtual LogosResult createNode(const QString &cfg) = 0;
-    Q_INVOKABLE virtual LogosResult start() = 0;
-    Q_INVOKABLE virtual LogosResult stop() = 0;
-    Q_INVOKABLE virtual LogosResult send(const QString &contentTopic, const QString &payload) = 0;
-    Q_INVOKABLE virtual LogosResult subscribe(const QString &contentTopic) = 0;
-    Q_INVOKABLE virtual LogosResult unsubscribe(const QString &contentTopic) = 0;
-    Q_INVOKABLE virtual LogosResult getAvailableNodeInfoIDs() = 0;
-    Q_INVOKABLE virtual LogosResult getNodeInfo(const QString &nodeInfoId) = 0;
-    Q_INVOKABLE virtual LogosResult getAvailableConfigs() = 0;
+    Q_INVOKABLE virtual QVariant createNode(const QString &cfg) = 0;
+    Q_INVOKABLE virtual QVariant start() = 0;
+    Q_INVOKABLE virtual QVariant stop() = 0;
+    Q_INVOKABLE virtual QVariant send(const QString &contentTopic, const QString &payload) = 0;
+    Q_INVOKABLE virtual QVariant subscribe(const QString &contentTopic) = 0;
+    Q_INVOKABLE virtual QVariant unsubscribe(const QString &contentTopic) = 0;
+    Q_INVOKABLE virtual QVariant getAvailableNodeInfoIDs() = 0;
+    Q_INVOKABLE virtual QVariant getNodeInfo(const QString &nodeInfoId) = 0;
+    Q_INVOKABLE virtual QVariant getAvailableConfigs() = 0;
 
 signals:
     void eventResponse(const QString& eventName, const QVariantList& data);

--- a/src/delivery_module_plugin.cpp
+++ b/src/delivery_module_plugin.cpp
@@ -17,6 +17,16 @@ extern "C" {
 #include <liblogosdelivery.h>
 }
 
+static QVariant logosResultToJson(const LogosResult& r) {
+    QJsonObject obj;
+    obj["success"] = r.success;
+    if (r.value.isValid() && !r.value.isNull())
+        obj["value"] = QJsonValue::fromVariant(r.value);
+    if (r.error.isValid() && !r.error.isNull())
+        obj["error"] = QJsonValue::fromVariant(r.error);
+    return QVariant(QString::fromUtf8(QJsonDocument(obj).toJson(QJsonDocument::Compact)));
+}
+
 DeliveryModulePlugin::DeliveryModulePlugin() : deliveryCtx(nullptr)
 {
     qDebug() << "DeliveryModulePlugin: Initializing...";
@@ -149,13 +159,13 @@ void DeliveryModulePlugin::initLogos(LogosAPI* logosAPIInstance) {
     logosAPI = logosAPIInstance;
 }
 
-LogosResult DeliveryModulePlugin::createNode(const QString &cfg)
+QVariant DeliveryModulePlugin::createNode(const QString &cfg)
 {
     std::lock_guard<std::mutex> createNodeLock(createNodeMutex);
 
     if (deliveryCtx != nullptr) {
         qWarning() << "DeliveryModulePlugin: createNode rejected - context already initialized";
-        return {false, QVariant(), QStringLiteral("Context not initialized")};
+        return logosResultToJson({false, QVariant(), QStringLiteral("Context not initialized")});
     }
 
     qDebug() << "DeliveryModulePlugin::createNode called with cfg:" << cfg;
@@ -227,7 +237,7 @@ LogosResult DeliveryModulePlugin::createNode(const QString &cfg)
         deliveryCtx = nullptr;
 
         qWarning() << "DeliveryModulePlugin: Timeout waiting for createNode callback";
-        return {false, QVariant(), QStringLiteral("Timeout waiting for createNode callback")};
+        return logosResultToJson({false, QVariant(), QStringLiteral("Timeout waiting for createNode callback")});
     }
 
     // Any issue happened during node creation means the context is destroyed and must not be user.
@@ -239,26 +249,26 @@ LogosResult DeliveryModulePlugin::createNode(const QString &cfg)
         deliveryCtx = nullptr;
 
         qWarning() << "DeliveryModulePlugin: Failed to create Delivery context";
-        return {false, QVariant(), QStringLiteral("Failed to create Delivery context")};
+        return logosResultToJson({false, QVariant(), QStringLiteral("Failed to create Delivery context")});
     }
-    
+
     // Success case - deliveryCtx is valid and callback returned RET_OK.
     qDebug() << "DeliveryModulePlugin: Delivery context created successfully";
-    
+
     // Set up event callback
     logosdelivery_set_event_callback(deliveryCtx, event_callback, this);
-    return {true, {}};
+    return logosResultToJson({true, {}});
 }
 
-LogosResult DeliveryModulePlugin::start()
+QVariant DeliveryModulePlugin::start()
 {
     qDebug() << "DeliveryModulePlugin::start called";
     
     if (!deliveryCtx) {
         qWarning() << "DeliveryModulePlugin: Cannot start Delivery - context not initialized. Call createNode first.";
-        return {false, QVariant(), QStringLiteral("Context not initialized")};
+        return logosResultToJson({false, QVariant(), QStringLiteral("Context not initialized")});
     }
-    
+
     auto outcome = callApiRetVoid(
         "start",
         CALLBACK_TIMEOUT,
@@ -269,18 +279,18 @@ LogosResult DeliveryModulePlugin::start()
     }
 
     qDebug() << "DeliveryModulePlugin: Delivery start completed with success";
-    return outcome;
+    return logosResultToJson(outcome);
 }
 
-LogosResult DeliveryModulePlugin::stop()
+QVariant DeliveryModulePlugin::stop()
 {
     qDebug() << "DeliveryModulePlugin::stop called";
     
     if (!deliveryCtx) {
         qWarning() << "DeliveryModulePlugin: Cannot stop Delivery - context not initialized. Call createNode first.";
-        return {false, QVariant(), QStringLiteral("Context not initialized")};
+        return logosResultToJson({false, QVariant(), QStringLiteral("Context not initialized")});
     }
-    
+
     auto outcome = callApiRetVoid(
         "stop",
         CALLBACK_TIMEOUT,
@@ -291,16 +301,16 @@ LogosResult DeliveryModulePlugin::stop()
     }
 
     qDebug() << "DeliveryModulePlugin: Delivery stop completed with success";
-    return outcome;
+    return logosResultToJson(outcome);
 }
-LogosResult DeliveryModulePlugin::send(const QString &contentTopic, const QString &payload)
+QVariant DeliveryModulePlugin::send(const QString &contentTopic, const QString &payload)
 {
     qDebug() << "DeliveryModulePlugin::send called with contentTopic:" << contentTopic;
     qDebug() << "DeliveryModulePlugin::send payload:" << payload;
 
     if (!deliveryCtx) {
         qWarning() << "DeliveryModulePlugin: Cannot send message - context not initialized. Call createNode first.";
-        return {false, QVariant(), QStringLiteral("Context not initialized")};
+        return logosResultToJson({false, QVariant(), QStringLiteral("Context not initialized")});
     }
 
     // Construct JSON message according to logosdelivery_send API
@@ -324,21 +334,21 @@ LogosResult DeliveryModulePlugin::send(const QString &contentTopic, const QStrin
 
     const QString responseMessage = outcome.getString();
     qDebug() << "DeliveryModulePlugin: Send initiated for topic:" << contentTopic << ", with success, requestId: " << responseMessage;
-    return outcome;
+    return logosResultToJson(outcome);
 }
 
-LogosResult DeliveryModulePlugin::subscribe(const QString &contentTopic)
+QVariant DeliveryModulePlugin::subscribe(const QString &contentTopic)
 {
     qDebug() << "DeliveryModulePlugin::subscribe called with contentTopic:" << contentTopic;
     
     if (!deliveryCtx) {
         qWarning() << "DeliveryModulePlugin: Cannot subscribe - context not initialized. Call createNode first.";
-        return {false, QVariant(), QStringLiteral("Context not initialized")};
+        return logosResultToJson({false, QVariant(), QStringLiteral("Context not initialized")});
     }
-    
+
     // Convert QString to UTF-8 byte array
     QByteArray topicUtf8 = contentTopic.toUtf8();
-    
+
     auto outcome = callApiRetVoid(
         "subscribe",
         CALLBACK_TIMEOUT,
@@ -349,21 +359,21 @@ LogosResult DeliveryModulePlugin::subscribe(const QString &contentTopic)
     }
 
     qDebug() << "DeliveryModulePlugin: Subscribe completed for topic:" << contentTopic << " with success";
-    return outcome;
+    return logosResultToJson(outcome);
 }
 
-LogosResult DeliveryModulePlugin::unsubscribe(const QString &contentTopic)
+QVariant DeliveryModulePlugin::unsubscribe(const QString &contentTopic)
 {
     qDebug() << "DeliveryModulePlugin::unsubscribe called with contentTopic:" << contentTopic;
     
     if (!deliveryCtx) {
         qWarning() << "DeliveryModulePlugin: Cannot unsubscribe - context not initialized.";
-        return {false, QVariant(), QStringLiteral("Context not initialized")};
+        return logosResultToJson({false, QVariant(), QStringLiteral("Context not initialized")});
     }
-    
+
     // Convert QString to UTF-8 byte array
     QByteArray topicUtf8 = contentTopic.toUtf8();
-    
+
     auto outcome = callApiRetVoid(
         "unsubscribe",
         CALLBACK_TIMEOUT,
@@ -374,7 +384,7 @@ LogosResult DeliveryModulePlugin::unsubscribe(const QString &contentTopic)
     }
 
     qDebug() << "DeliveryModulePlugin: Unsubscribe completed for topic:" << contentTopic << " with success";
-    return outcome;
+    return logosResultToJson(outcome);
 }
 
 QString DeliveryModulePlugin::version() const {
@@ -403,13 +413,13 @@ QString DeliveryModulePlugin::version() const {
     return moduleVersion + " (liblogosdelivery version: " + version + ")";
 }
 
-LogosResult DeliveryModulePlugin::getAvailableNodeInfoIDs() {
+QVariant DeliveryModulePlugin::getAvailableNodeInfoIDs() {
     
     qDebug() << "DeliveryModulePlugin::getAvailableNodeInfoIDs called";
 
     if (!deliveryCtx) {
         qWarning() << "DeliveryModulePlugin: Cannot get available node info IDs - context not initialized. Call createNode first.";
-        return {false, QVariant(), QStringLiteral("Context not initialized")};
+        return logosResultToJson({false, QVariant(), QStringLiteral("Context not initialized")});
     }
     auto outcome = callApiRetValue(
         "get_available_node_info_ids",
@@ -419,15 +429,15 @@ LogosResult DeliveryModulePlugin::getAvailableNodeInfoIDs() {
     if (!outcome.success) {
         qWarning() << "DeliveryModulePlugin: Get available node info IDs failed, reason:" << outcome.getError();
     }
-    return outcome;
+    return logosResultToJson(outcome);
 }
 
-LogosResult DeliveryModulePlugin::getNodeInfo(const QString &nodeInfoId) {
+QVariant DeliveryModulePlugin::getNodeInfo(const QString &nodeInfoId) {
     qDebug() << "DeliveryModulePlugin::getNodeInfo called with nodeInfoId:" << nodeInfoId;
 
     if (!deliveryCtx) {
         qWarning() << "DeliveryModulePlugin: Cannot get node info - context not initialized. Call createNode first.";
-        return {false, QVariant(), QStringLiteral("Context not initialized")};
+        return logosResultToJson({false, QVariant(), QStringLiteral("Context not initialized")});
     }
     auto outcome = callApiRetValue(
         "get_node_info",
@@ -439,15 +449,15 @@ LogosResult DeliveryModulePlugin::getNodeInfo(const QString &nodeInfoId) {
             ", reason:" << outcome.getError();
     }
 
-    return outcome;
+    return logosResultToJson(outcome);
 }
 
-LogosResult DeliveryModulePlugin::getAvailableConfigs() {
+QVariant DeliveryModulePlugin::getAvailableConfigs() {
     qDebug() << "DeliveryModulePlugin::getAvailableConfigs called";
 
     if (!deliveryCtx) {
         qWarning() << "DeliveryModulePlugin: Cannot get available configs - context not initialized. Call createNode first.";
-        return {false, QVariant(), QStringLiteral("Context not initialized")};
+        return logosResultToJson({false, QVariant(), QStringLiteral("Context not initialized")});
     }
     auto outcome = callApiRetValue(
         "get_available_configs",
@@ -458,5 +468,5 @@ LogosResult DeliveryModulePlugin::getAvailableConfigs() {
         qWarning() << "DeliveryModulePlugin: Get available configs failed, reason:" << outcome.getError();
     }
 
-    return outcome;
+    return logosResultToJson(outcome);
 }

--- a/src/delivery_module_plugin.h
+++ b/src/delivery_module_plugin.h
@@ -6,6 +6,7 @@
 #include "delivery_module_interface.h"
 #include "logos_api.h"
 #include "logos_api_client.h"
+#include "logos_types.h"
 
 /**
  * @brief Concrete Qt plugin implementing the delivery messaging module.
@@ -137,19 +138,19 @@ public:
      * @return `true` if context creation succeeds and callback returns `RET_OK`,
      *         otherwise `false`.
      */
-    Q_INVOKABLE LogosResult createNode(const QString &cfg) override;
+    Q_INVOKABLE QVariant createNode(const QString &cfg) override;
 
     /**
      * @brief Starts the delivery node.
      * @return `true` on success; `false` when no context exists or start fails.
      */
-    Q_INVOKABLE LogosResult start() override;
+    Q_INVOKABLE QVariant start() override;
 
     /**
      * @brief Stops the delivery node.
      * @return `true` on success; `false` when no context exists or stop fails.
      */
-    Q_INVOKABLE LogosResult stop() override;
+    Q_INVOKABLE QVariant stop() override;
 
     /**
      * @brief Sends a message over the active node.
@@ -170,34 +171,34 @@ public:
      *                bytes and base64-encoded before crossing the FFI boundary.
      * @return Success with request id, or error details.
      */
-    Q_INVOKABLE LogosResult send(const QString &contentTopic, const QString &payload) override;
+    Q_INVOKABLE QVariant send(const QString &contentTopic, const QString &payload) override;
 
     /**
      * @brief Subscribes to the supplied content topic.
      * @param contentTopic Topic identifier.
      * @return `true` when subscribed successfully, otherwise `false`.
      */
-    Q_INVOKABLE LogosResult subscribe(const QString &contentTopic) override;
+    Q_INVOKABLE QVariant subscribe(const QString &contentTopic) override;
 
     /**
      * @brief Unsubscribes from the supplied content topic.
      * @param contentTopic Topic identifier.
      * @return `true` when unsubscribed successfully, otherwise `false`.
      */
-    Q_INVOKABLE LogosResult unsubscribe(const QString &contentTopic) override;
-    Q_INVOKABLE LogosResult getAvailableNodeInfoIDs() override;
+    Q_INVOKABLE QVariant unsubscribe(const QString &contentTopic) override;
+    Q_INVOKABLE QVariant getAvailableNodeInfoIDs() override;
 
     /**
      * @brief Semantic version of this plugin implementation.
      * @param nodeInfoId Identifier for the requested node info item.
      * @return UTF-16 string containing UTF-8 serializable JSON data, or an empty string on error.
      */
-    Q_INVOKABLE LogosResult getNodeInfo(const QString &nodeInfoId) override;
+    Q_INVOKABLE QVariant getNodeInfo(const QString &nodeInfoId) override;
 
     /**
      * @brief Information about the available configuration parameters to be used in `createNode`.
      */
-    Q_INVOKABLE LogosResult getAvailableConfigs() override;
+    Q_INVOKABLE QVariant getAvailableConfigs() override;
 
     QString name() const override { return "delivery_module"; }
 


### PR DESCRIPTION
## Problem

`LogosResult` (from `logos_types.h`) is a plain C++ struct with `bool success`, `QVariant value`, `QVariant error` and `QDataStream` operators — but **no `Q_DECLARE_METATYPE`**. The QRemoteObjects layer cannot deserialize it when it crosses the wire to the AppImage host process, so every `logos.callModule()` call silently returns `null`. No error is logged, the module process is running, but every method response is dropped.

This makes the module completely unusable from a QML UI in the AppImage runtime.

## Fix

- Change all `Q_INVOKABLE` return types in `DeliveryModuleInterface` and `DeliveryModulePlugin` from `LogosResult` to `QVariant`
- Add a static `logosResultToJson()` helper in `delivery_module_plugin.cpp` that converts `LogosResult` → compact JSON string wrapped in `QVariant`:
  ```cpp
  static QVariant logosResultToJson(const LogosResult& r) {
      QJsonObject obj;
      obj["success"] = r.success;
      if (r.value.isValid() && !r.value.isNull())
          obj["value"] = QJsonValue::fromVariant(r.value);
      if (r.error.isValid() && !r.error.isNull())
          obj["error"] = QJsonValue::fromVariant(r.error);
      return QVariant(QString::fromUtf8(QJsonDocument(obj).toJson(QJsonDocument::Compact)));
  }
  ```
- All 15 return sites updated to use the helper
- `logos_types.h` moved from the public interface header to `plugin.h` (internal only)
- `api_call_handler.h` is unchanged — `LogosResult` is still used internally

`QVariant` containing a `QString` is always safely serialized by QRO. The JSON format matches what QML callers expect (`{"success": bool, "value": ..., "error": ...}`).

## Testing

Tested with `delivery_probe_ui` QML plugin in AppImage `pre-release` (AppImage 193+):
- `createNode` → `{"success":true}`
- `start` → `{"success":true}`
- `subscribe` → `{"success":true}`
- `getNodeInfo("MyPeerId")` → `{"success":true,"value":"16Uiu2..."}`

All previously returned `null`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)