### PR TITLE
fix: use QByteArray for payload end to end

### DIFF
--- a/src/delivery_module_interface.h
+++ b/src/delivery_module_interface.h
@@ -11,7 +11,7 @@ public:
     Q_INVOKABLE virtual LogosResult createNode(const QString &cfg) = 0;
     Q_INVOKABLE virtual LogosResult start() = 0;
     Q_INVOKABLE virtual LogosResult stop() = 0;
-    Q_INVOKABLE virtual LogosResult send(const QString &contentTopic, const QString &payload) = 0;
+    Q_INVOKABLE virtual LogosResult send(const QString &contentTopic, const QByteArray &payload) = 0;
     Q_INVOKABLE virtual LogosResult subscribe(const QString &contentTopic) = 0;
     Q_INVOKABLE virtual LogosResult unsubscribe(const QString &contentTopic) = 0;
     Q_INVOKABLE virtual LogosResult getAvailableNodeInfoIDs() = 0;

--- a/src/delivery_module_plugin.cpp
+++ b/src/delivery_module_plugin.cpp
@@ -112,8 +112,6 @@ void DeliveryModulePlugin::event_callback(int callerRet, const char* msg, size_t
             eventData << jsonObj["messageHash"].toString();
             eventData << msgObj["contentTopic"].toString();
 
-            // The waku API returns payload as a JSON byte array (e.g. [106,106,106,106]).
-            // Convert it to a base64 string to match the documented event contract.
             QJsonValue payloadValue = msgObj["payload"];
             if (payloadValue.isArray()) {
                 QJsonArray payloadArray = payloadValue.toArray();
@@ -122,9 +120,9 @@ void DeliveryModulePlugin::event_callback(int callerRet, const char* msg, size_t
                 for (const QJsonValue& val : payloadArray) {
                     payloadBytes.append(static_cast<char>(val.toInt()));
                 }
-                eventData << QString::fromLatin1(payloadBytes.toBase64());
+                eventData << payloadBytes;
             } else {
-                eventData << payloadValue.toString();
+                eventData << QByteArray::fromBase64(payloadValue.toString().toLatin1());
             }
 
             eventData << QString::number(msgObj["timestamp"].toDouble(), 'f', 0);
@@ -293,10 +291,9 @@ LogosResult DeliveryModulePlugin::stop()
     qDebug() << "DeliveryModulePlugin: Delivery stop completed with success";
     return outcome;
 }
-LogosResult DeliveryModulePlugin::send(const QString &contentTopic, const QString &payload)
+LogosResult DeliveryModulePlugin::send(const QString &contentTopic, const QByteArray &payload)
 {
     qDebug() << "DeliveryModulePlugin::send called with contentTopic:" << contentTopic;
-    qDebug() << "DeliveryModulePlugin::send payload:" << payload;
 
     if (!deliveryCtx) {
         qWarning() << "DeliveryModulePlugin: Cannot send message - context not initialized. Call createNode first.";
@@ -307,7 +304,7 @@ LogosResult DeliveryModulePlugin::send(const QString &contentTopic, const QStrin
     // The payload should be base64-encoded as per the API spec
     QJsonObject messageObj;
     messageObj["contentTopic"] = contentTopic;
-    messageObj["payload"] = QString::fromUtf8(payload.toUtf8().toBase64());
+    messageObj["payload"] = QString::fromUtf8(payload.toBase64());
     messageObj["ephemeral"] = false;
 
     QJsonDocument doc(messageObj);

--- a/src/delivery_module_plugin.h
+++ b/src/delivery_module_plugin.h
@@ -38,7 +38,7 @@
  * - `messageReceived` (emitted when a message arrives on a subscribed topic)
  *   - `data[0]` (`QString`): message hash
  *   - `data[1]` (`QString`): content topic
- *   - `data[2]` (`QString`): payload (base64-encoded)
+ *   - `data[2]` (`QByteArray`): payload (raw bytes)
  *   - `data[3]` (`QString`): timestamp (nanoseconds since epoch)
  * - `connectionStateChanged`
  *   - `data[0]` (`QString`): connection status
@@ -166,11 +166,10 @@ public:
      * - `messageSent` emitted after the sent message is validated by the network.
      * 
      * @param contentTopic Destination content topic.
-     * @param payload Raw message bytes represented as QString; converted to UTF-8
-     *                bytes and base64-encoded before crossing the FFI boundary.
+     * @param payload Raw message bytes; base64-encoded before crossing the FFI boundary.
      * @return Success with request id, or error details.
      */
-    Q_INVOKABLE LogosResult send(const QString &contentTopic, const QString &payload) override;
+    Q_INVOKABLE LogosResult send(const QString &contentTopic, const QByteArray &payload) override;
 
     /**
      * @brief Subscribes to the supplied content topic.

--- a/tests/test_delivery_module.cpp
+++ b/tests/test_delivery_module.cpp
@@ -108,7 +108,7 @@ LOGOS_TEST(send_fails_without_createNode) {
     auto t = LogosTestContext("delivery_module");
     DeliveryModulePlugin plugin;
 
-    LogosResult result = plugin.send("/test/1/delivery/proto", "hello");
+    LogosResult result = plugin.send("/test/1/delivery/proto", QByteArray("hello"));
     LOGOS_ASSERT_FALSE(result.success);
 }
 
@@ -117,7 +117,7 @@ LOGOS_TEST(send_succeeds_and_returns_request_id) {
     auto* plugin = createInitializedPlugin(t);
 
     t.mockCFunction("logosdelivery_send").returns("req-id-abc123");
-    LogosResult result = plugin->send("/test/1/delivery/proto", "hello world");
+    LogosResult result = plugin->send("/test/1/delivery/proto", QByteArray("hello world"));
 
     LOGOS_ASSERT_TRUE(result.success);
     LOGOS_ASSERT_EQ(result.getString().toStdString(), std::string("req-id-abc123"));
@@ -126,12 +126,12 @@ LOGOS_TEST(send_succeeds_and_returns_request_id) {
     delete plugin;
 }
 
-LOGOS_TEST(send_calls_ffi_with_base64_encoded_payload) {
+LOGOS_TEST(send_calls_ffi_with_byte_array_payload) {
     auto t = LogosTestContext("delivery_module");
     auto* plugin = createInitializedPlugin(t);
 
     t.mockCFunction("logosdelivery_send").returns("req-id-xyz");
-    LogosResult result = plugin->send("/test/1/delivery/proto", "test-payload");
+    LogosResult result = plugin->send("/test/1/delivery/proto", QByteArray("test-payload"));
 
     LOGOS_ASSERT_TRUE(result.success);
     LOGOS_ASSERT_EQ(t.cFunctionCallCount("logosdelivery_send"), 1);
@@ -144,7 +144,7 @@ LOGOS_TEST(send_returns_error_on_ffi_failure) {
     auto* plugin = createInitializedPlugin(t);
 
     DeliveryModulePlugin pluginNoCtx;
-    LogosResult failResult = pluginNoCtx.send("/topic", "payload");
+    LogosResult failResult = pluginNoCtx.send("/topic", QByteArray("payload"));
     LOGOS_ASSERT_FALSE(failResult.success);
     LOGOS_ASSERT_FALSE(failResult.getError<QString>().isEmpty());
 


### PR DESCRIPTION
## Summary

- `send()` parameter changed from `QString` to `QByteArray` — base64 encoding is still applied internally before crossing the FFI boundary, but callers no longer need to think about encoding
- `messageReceived` event now emits `data[2]` as `QByteArray` (raw bytes) instead of a base64-encoded `QString`, matching the behaviour of `logos-delivery` itself
- Updated interface, plugin header/impl, docs, and unit tests accordingly

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)