### PR TITLE
fix: unify event timestamp format to nanoseconds since epoch

### DIFF
--- a/src/delivery_module_plugin.cpp
+++ b/src/delivery_module_plugin.cpp
@@ -78,7 +78,7 @@ void DeliveryModulePlugin::event_callback(int callerRet, const char* msg, size_t
         
         QJsonObject jsonObj = doc.object();
         QString eventType = jsonObj["eventType"].toString();
-        QString timestamp = QDateTime::currentDateTime().toString(Qt::ISODate);
+        qint64 timestamp = QDateTime::currentDateTimeUtc().toMSecsSinceEpoch() * Q_INT64_C(1000000);
         
         if (eventType == "message_sent") {
             // MessageSentEvent: requestId, messageHash
@@ -125,7 +125,7 @@ void DeliveryModulePlugin::event_callback(int callerRet, const char* msg, size_t
                 eventData << QByteArray::fromBase64(payloadValue.toString().toLatin1());
             }
 
-            eventData << QString::number(msgObj["timestamp"].toDouble(), 'f', 0);
+            eventData << static_cast<qint64>(msgObj["timestamp"].toDouble());
             plugin->emitEvent("messageReceived", eventData);
 
         } else if (eventType == "connection_status_change") {

--- a/src/delivery_module_plugin.h
+++ b/src/delivery_module_plugin.h
@@ -25,24 +25,24 @@
  * - `messageSent` (see `send` method)
  *   - `data[0]` (`QString`): request id
  *   - `data[1]` (`QString`): message hash
- *   - `data[2]` (`QString`): local timestamp (nanoseconds since epoch)
+ *   - `data[2]` (`qint64`): local timestamp (nanoseconds since epoch)
  * - `messageError` (see `send` method)
  *   - `data[0]` (`QString`): request id
  *   - `data[1]` (`QString`): message hash
  *   - `data[2]` (`QString`): error message
- *   - `data[3]` (`QString`): local timestamp (nanoseconds since epoch)
+ *   - `data[3]` (`qint64`): local timestamp (nanoseconds since epoch)
  * - `messagePropagated` (see `send` method)
  *   - `data[0]` (`QString`): request id
  *   - `data[1]` (`QString`): message hash
- *   - `data[2]` (`QString`): local timestamp (nanoseconds since epoch)
+ *   - `data[2]` (`qint64`): local timestamp (nanoseconds since epoch)
  * - `messageReceived` (emitted when a message arrives on a subscribed topic)
  *   - `data[0]` (`QString`): message hash
  *   - `data[1]` (`QString`): content topic
  *   - `data[2]` (`QByteArray`): payload (raw bytes)
- *   - `data[3]` (`QString`): message timestamp (nanoseconds since epoch)
+ *   - `data[3]` (`qint64`): message timestamp (nanoseconds since epoch)
  * - `connectionStateChanged`
  *   - `data[0]` (`QString`): connection status
- *   - `data[1]` (`QString`): local timestamp (nanoseconds since epoch)
+ *   - `data[1]` (`qint64`): local timestamp (nanoseconds since epoch)
  *
  * The raw FFI `eventType` values mapped into these plugin events are:
  * - `message_sent` -> `messageSent`

--- a/src/delivery_module_plugin.h
+++ b/src/delivery_module_plugin.h
@@ -25,24 +25,24 @@
  * - `messageSent` (see `send` method)
  *   - `data[0]` (`QString`): request id
  *   - `data[1]` (`QString`): message hash
- *   - `data[2]` (`QString`): local timestamp (ISO-8601)
+ *   - `data[2]` (`QString`): local timestamp (nanoseconds since epoch)
  * - `messageError` (see `send` method)
  *   - `data[0]` (`QString`): request id
  *   - `data[1]` (`QString`): message hash
  *   - `data[2]` (`QString`): error message
- *   - `data[3]` (`QString`): local timestamp (ISO-8601)
+ *   - `data[3]` (`QString`): local timestamp (nanoseconds since epoch)
  * - `messagePropagated` (see `send` method)
  *   - `data[0]` (`QString`): request id
  *   - `data[1]` (`QString`): message hash
- *   - `data[2]` (`QString`): local timestamp (ISO-8601)
+ *   - `data[2]` (`QString`): local timestamp (nanoseconds since epoch)
  * - `messageReceived` (emitted when a message arrives on a subscribed topic)
  *   - `data[0]` (`QString`): message hash
  *   - `data[1]` (`QString`): content topic
  *   - `data[2]` (`QByteArray`): payload (raw bytes)
- *   - `data[3]` (`QString`): timestamp (nanoseconds since epoch)
+ *   - `data[3]` (`QString`): message timestamp (nanoseconds since epoch)
  * - `connectionStateChanged`
  *   - `data[0]` (`QString`): connection status
- *   - `data[1]` (`QString`): local timestamp (ISO-8601)
+ *   - `data[1]` (`QString`): local timestamp (nanoseconds since epoch)
  *
  * The raw FFI `eventType` values mapped into these plugin events are:
  * - `message_sent` -> `messageSent`


### PR DESCRIPTION
## Summary

Fixes #26.

All five module events now emit timestamps as `qint64` nanoseconds since epoch (carried as a `QVariant` in the `data` list). Previously:

- `messageSent`, `messageError`, `messagePropagated`, `connectionStateChanged` — emitted a local ISO-8601 string
- `messageReceived` — passed the raw waku network timestamp as a stringified float of nanoseconds

Consumers had to special-case `messageReceived`. Now the format is uniform across all events.

## Changes

- **`delivery_module_plugin.cpp`**: replace `QDateTime::currentDateTime().toString(Qt::ISODate)` with `QDateTime::currentDateTimeUtc().toMSecsSinceEpoch() * 1000000` (a `qint64`); replace the `QString::number(..., 'f', 0)` cast on the waku timestamp with `static_cast<qint64>(...)`
- **`delivery_module_plugin.h`**: update all event contract doc comments from "ISO-8601" to "nanoseconds since epoch"