### PR TITLE
fix: send() forwards payload as-is instead of wrapping it into base64

### DIFF
--- a/src/delivery_module_plugin.cpp
+++ b/src/delivery_module_plugin.cpp
@@ -303,11 +303,11 @@ LogosResult DeliveryModulePlugin::send(const QString &contentTopic, const QStrin
         return {false, QVariant(), QStringLiteral("Context not initialized")};
     }
 
-    // Construct JSON message according to logosdelivery_send API
-    // The payload should be base64-encoded as per the API spec
+    // `payload` is forwarded as-is: logosdelivery_send base64-decodes it once
+    // before publishing, so the contract is base64-in / raw-bytes-on-wire.
     QJsonObject messageObj;
     messageObj["contentTopic"] = contentTopic;
-    messageObj["payload"] = QString::fromUtf8(payload.toUtf8().toBase64());
+    messageObj["payload"] = payload;
     messageObj["ephemeral"] = false;
 
     QJsonDocument doc(messageObj);

--- a/src/delivery_module_plugin.h
+++ b/src/delivery_module_plugin.h
@@ -166,8 +166,8 @@ public:
      * - `messageSent` emitted after the sent message is validated by the network.
      * 
      * @param contentTopic Destination content topic.
-     * @param payload Raw message bytes represented as QString; converted to UTF-8
-     *                bytes and base64-encoded before crossing the FFI boundary.
+     * @param payload      Base64-encoded payload. Forwarded unchanged; the
+     *                     decoded bytes are what end up on the wire.
      * @return Success with request id, or error details.
      */
     Q_INVOKABLE LogosResult send(const QString &contentTopic, const QString &payload) override;


### PR DESCRIPTION
The previous implementation called `payload.toUtf8().toBase64()` and documented `payload` as "Raw message bytes represented as QString". That contract is unsound: QString cannot losslessly carry arbitrary bytes. QString is UTF-16 internally, so `toUtf8()` is not a memcpy -- it re-encodes through `QStringConverter`. Per Qt docs (https://doc.qt.io/qt-6/qstringconverter.html#Flag-enum), invalid UTF-16 input is replaced by `QChar::ReplacementCharacter` (U+FFFD, three UTF-8 bytes `EF BF BD`) under the default flag. A QString therefore does not survive a `toUtf8` round-trip cleanly whenever it does not represent valid Unicode text, such as arbitrary binary buffers stuffed into a QString (encrypted ciphertext, compressed blobs, protobuf bytes).

The fix changes the contract so `payload` is assumed to already be a base64-encoded string and `send()` forwards it unchanged into the JSON envelope.

The proper fix is to change `QString` to `QByteArray`, but that would be a breaking change to the function signature -- leaving it as a follow-up.