### PR TITLE
feat(delivery_module): add queryStore via logosdelivery_query_store

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ The delivery module provides the following API methods (all synchronous, all ret
 - `send(contentTopic: QString, payload: QString)` - Send a message (returns a request id)
 - `subscribe(contentTopic: QString)` - Subscribe to receive messages on a topic
 - `unsubscribe(contentTopic: QString)` - Unsubscribe from a topic
+- `queryStore(jsonQuery: QString, peerAddr: QString, timeoutMs: int)` -
+  Query historical messages via Waku Store (`jsonQuery` is Store request JSON;
+  `peerAddr` is comma-separated multiaddrs; `timeoutMs` caps wait for the FFI
+  callback, defaulting to 30s when `<= 0`)
 - `getAvailableNodeInfoIDs()` - List queryable node info identifiers
 - `getNodeInfo(nodeInfoId: QString)` - Retrieve node info by identifier
 - `getAvailableConfigs()` - Retrieve available configuration parameter descriptions
@@ -165,10 +169,22 @@ in a JSON envelope before crossing the FFI boundary:
 The call is synchronous and returns a **request id** on success. The actual
 network delivery is asynchronous — track results via the emitted events:
 
+
 - **`messageError`** – the module could not send the message.
 - **`messagePropagated`** – the message reached the network but is not yet
   validated.
 - **`messageSent`** – the message has been confirmed by the network.
+
+### Historical messages (`queryStore`)
+
+`queryStore(jsonQuery, peerAddr, timeoutMs)` forwards to `logosdelivery_query_store` in
+liblogosdelivery. `jsonQuery` is the UTF-8 Store request JSON (same fields as
+`library/kernel_api/protocols/store_api.nim` in logos-delivery). `peerAddr` is a
+comma-separated list of multiaddrs for the store peer. `timeoutMs` caps how long the
+module waits for the FFI callback; values less than or equal to zero use 30 seconds.
+
+On success, `LogosResult` carries a `QString` whose UTF-8 bytes are JSON describing the
+hex-encoded store response.
 
 ### Events
 

--- a/src/delivery_module_interface.h
+++ b/src/delivery_module_interface.h
@@ -14,6 +14,7 @@ public:
     Q_INVOKABLE virtual LogosResult send(const QString &contentTopic, const QByteArray &payload) = 0;
     Q_INVOKABLE virtual LogosResult subscribe(const QString &contentTopic) = 0;
     Q_INVOKABLE virtual LogosResult unsubscribe(const QString &contentTopic) = 0;
+    Q_INVOKABLE virtual LogosResult queryStore(const QString &jsonQuery, const QString &peerAddr, int timeoutMs) = 0;
     Q_INVOKABLE virtual LogosResult getAvailableNodeInfoIDs() = 0;
     Q_INVOKABLE virtual LogosResult getNodeInfo(const QString &nodeInfoId) = 0;
     Q_INVOKABLE virtual LogosResult getAvailableConfigs() = 0;

--- a/src/delivery_module_plugin.cpp
+++ b/src/delivery_module_plugin.cpp
@@ -5,6 +5,8 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonArray>
+#include <algorithm>
+#include <climits>
 #include <memory>
 #include <mutex>
 #include <semaphore>
@@ -346,6 +348,45 @@ LogosResult DeliveryModulePlugin::subscribe(const QString &contentTopic)
     }
 
     qDebug() << "DeliveryModulePlugin: Subscribe completed for topic:" << contentTopic << " with success";
+    return outcome;
+}
+
+LogosResult DeliveryModulePlugin::queryStore(const QString &jsonQuery, const QString &peerAddr, int timeoutMs)
+{
+    qDebug() << "DeliveryModulePlugin::queryStore called";
+
+    if (!deliveryCtx) {
+        qWarning() << "DeliveryModulePlugin: Cannot query Store - context not initialized. Call createNode first.";
+        return {false, QVariant(), QStringLiteral("Context not initialized")};
+    }
+
+    QByteArray jsonUtf8 = jsonQuery.toUtf8();
+    QByteArray peerUtf8 = peerAddr.toUtf8();
+
+    long long effectiveMs = timeoutMs > 0 ? static_cast<long long>(timeoutMs) : 30000LL;
+    if (effectiveMs > INT_MAX) {
+        effectiveMs = INT_MAX;
+    }
+
+    // callApiRetValue expects std::chrono::seconds (same as send/subscribe helpers).
+    const std::chrono::seconds callbackWaitSeconds(
+        std::max<long long>(1LL, (effectiveMs + 999) / 1000));
+    const int ffiTimeoutMs = static_cast<int>(effectiveMs);
+
+    auto outcome = callApiRetValue(
+        "query_store",
+        callbackWaitSeconds,
+        bindApiCall(
+            logosdelivery_query_store,
+            deliveryCtx,
+            jsonUtf8.constData(),
+            peerUtf8.constData(),
+            ffiTimeoutMs));
+
+    if (!outcome.success) {
+        qWarning() << "DeliveryModulePlugin: queryStore failed:" << outcome.getError();
+    }
+
     return outcome;
 }
 

--- a/src/delivery_module_plugin.h
+++ b/src/delivery_module_plugin.h
@@ -16,7 +16,7 @@
  * Lifecycle contract:
  * - call @ref createNode exactly once per context
  * - call @ref start before message operations
- * - use @ref subscribe / @ref send / @ref unsubscribe as needed
+ * - use @ref subscribe / @ref send / @ref unsubscribe / @ref queryStore as needed
  * - call @ref stop before shutdown
  * Notice all of these calls are synchronous.
  * 
@@ -184,6 +184,19 @@ public:
      * @return `true` when unsubscribed successfully, otherwise `false`.
      */
     Q_INVOKABLE LogosResult unsubscribe(const QString &contentTopic) override;
+
+    /**
+     * @brief Queries a peer via Waku Store (historical messages).
+     *
+     * Forwards to ``logosdelivery_query_store`` in liblogosdelivery. ``jsonQuery`` is the
+     * UTF-8 Store query JSON (same shape as ``library/kernel_api/protocols/store_api``).
+     * ``peerAddr`` is comma-separated multiaddrs understood by logos-delivery peer parsing.
+     * ``timeoutMs`` bounds how long the module waits for the FFI callback; values ``<= 0`` use 30 seconds.
+     *
+     * On success, ``LogosResult`` data is a QString holding UTF-8 JSON (hex-encoded store response).
+     */
+    Q_INVOKABLE LogosResult queryStore(const QString &jsonQuery, const QString &peerAddr, int timeoutMs) override;
+
     Q_INVOKABLE LogosResult getAvailableNodeInfoIDs() override;
 
     /**

--- a/tests/mocks/mock_liblogosdelivery.cpp
+++ b/tests/mocks/mock_liblogosdelivery.cpp
@@ -96,4 +96,10 @@ int logosdelivery_get_available_configs(void* /*ctx*/, logosdelivery_callback cb
     return RET_OK;
 }
 
+int logosdelivery_query_store(void* /*ctx*/, logosdelivery_callback cb, void* userData, const char* /*jsonQuery*/, const char* /*peerAddr*/, int /*timeoutMs*/) {
+    LOGOS_CMOCK_RECORD("logosdelivery_query_store");
+    invokeOk("logosdelivery_query_store", cb, userData);
+    return RET_OK;
+}
+
 } // extern "C"

--- a/tests/stubs/lib/liblogosdelivery.h
+++ b/tests/stubs/lib/liblogosdelivery.h
@@ -51,6 +51,9 @@ int logosdelivery_get_available_node_info_ids(void* ctx, logosdelivery_callback 
 // Retrieve available configuration parameter descriptions.
 int logosdelivery_get_available_configs(void* ctx, logosdelivery_callback cb, void* userData);
 
+// Waku Store query: jsonQuery is Store request JSON; peerAddr comma-separated multiaddrs.
+int logosdelivery_query_store(void* ctx, logosdelivery_callback cb, void* userData, const char* jsonQuery, const char* peerAddr, int timeoutMs);
+
 #ifdef __cplusplus
 }
 #endif

--- a/tests/test_delivery_module.cpp
+++ b/tests/test_delivery_module.cpp
@@ -187,6 +187,43 @@ LOGOS_TEST(unsubscribe_succeeds_with_context) {
     delete plugin;
 }
 
+// queryStore
+
+LOGOS_TEST(queryStore_fails_without_createNode) {
+    auto t = LogosTestContext("delivery_module");
+    DeliveryModulePlugin plugin;
+
+    LogosResult result = plugin.queryStore(R"({"requestId":"r1","includeData":false,"paginationForward":true})", "/ip4/127.0.0.1/tcp/60000/p2p/16Uiu", 5000);
+    LOGOS_ASSERT_FALSE(result.success);
+}
+
+LOGOS_TEST(queryStore_succeeds_with_context) {
+    auto t = LogosTestContext("delivery_module");
+    auto* plugin = createInitializedPlugin(t);
+
+    t.mockCFunction("logosdelivery_query_store").returns(R"({"mock":"store-response"})");
+    LogosResult result = plugin->queryStore(R"({"requestId":"r1","includeData":false,"paginationForward":true})", "/ip4/127.0.0.1/tcp/60000/p2p/16Uiu", 5000);
+
+    LOGOS_ASSERT_TRUE(result.success);
+    LOGOS_ASSERT_EQ(result.getString().toStdString(), std::string(R"({"mock":"store-response"})"));
+    LOGOS_ASSERT(t.cFunctionCalled("logosdelivery_query_store"));
+
+    delete plugin;
+}
+
+LOGOS_TEST(queryStore_uses_default_timeout_when_non_positive) {
+    auto t = LogosTestContext("delivery_module");
+    auto* plugin = createInitializedPlugin(t);
+
+    t.mockCFunction("logosdelivery_query_store").returns("{}");
+    LogosResult result = plugin->queryStore("{}", "/ip4/127.0.0.1/tcp/60000/p2p/16Uiu", 0);
+
+    LOGOS_ASSERT_TRUE(result.success);
+    LOGOS_ASSERT_EQ(t.cFunctionCallCount("logosdelivery_query_store"), 1);
+
+    delete plugin;
+}
+
 // getAvailableNodeInfoIDs
 
 LOGOS_TEST(getAvailableNodeInfoIDs_returns_mocked_string) {


### PR DESCRIPTION
Wire Logos Store queries through liblogosdelivery with timeout handling, unit tests, mocks, and README documentation. Requires a liblogosdelivery revision that exports logosdelivery_query_store.

## Summary

- Adds `queryStore(jsonQuery, peerAddr, timeoutMs)` to the delivery module plugin surface and forwards to `logosdelivery_query_store` in liblogosdelivery.
- Extends unit stubs/mocks and adds unit tests; documents the API in `README.md`.

Addresses [Expose Store query functionality through delivery_module](https://github.com/logos-co/logos-delivery-module/issues/30) by letting callers issue Store queries via `LogosAPI`, alongside existing methods like `send` and `subscribe`.

Note: the issue text suggested the name `storeQuery`; this PR uses **`queryStore`** for verb-led parity with `send` / `subscribe`. The underlying C symbol is **`logosdelivery_query_store`**.

## Depends on

- https://github.com/logos-messaging/logos-delivery/pull/3888 (logos-delivery PR adding `logosdelivery_query_store`). After that PR merges, update **`flake.lock`** so the `logos-delivery` input points at the merged revision (or an equivalent tag/commit). Until then, reviewers can use `--override-input logos-delivery path:…` locally.

## Test plan

- [x] `nix build -L` with `logos-delivery` overridden to a revision containing `logosdelivery_query_store` (local Linux)
- [x] `nix build -L '.#unit-tests'` with the same override — `delivery_module_tests` passes (26 tests, incl. `queryStore_*`)
- [ ] `flake.lock` updated to merged `logos-delivery` revision — required for CI without override
- [ ] `nix build .#unit-tests` fully green incl. integration runner / macOS CI (see integration `libpq` env if still failing)

---

This pull request is AI generated; human review is needed.

Submitting this PR from a personal fork as apparently I lack write access to this repo.

This PR is in draft until https://github.com/logos-messaging/logos-delivery/pull/3888 is merged.