### PR TITLE
chore: fix logos-delivery version

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -753,11 +753,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779216144,
-        "narHash": "sha256-76zb0k/EWaqVtFVg9t3mI10wCJ/CDNNBvkX3HHvRJDo=",
+        "lastModified": 1779391868,
+        "narHash": "sha256-oEl4RwRfBOeKLUn3fZOY5FCpzp0tHMn44bhLzcoob18=",
         "owner": "logos-co",
         "repo": "logos-module-builder",
-        "rev": "b3f1d658f0e07c89bb4744f364d572ad1bcab8c9",
+        "rev": "539651325f46eea635576034775a0c209ce4d884",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -518,16 +518,17 @@
         "zerokit": "zerokit"
       },
       "locked": {
-        "lastModified": 1776170869,
-        "narHash": "sha256-bmudtYQv702S7dt7WLV+MYAgNtSE7539Kw+qU7NvCyA=",
+        "lastModified": 1778859578,
+        "narHash": "sha256-5Md+vsFhK44QN6+YJYQc67A6VNti/EpFtOof0BZ/yKE=",
         "ref": "refs/heads/master",
-        "rev": "ecd3758580015a3fb80bb0461d736a8b4c539c64",
-        "revCount": 2299,
+        "rev": "34c197c5cdad1d5787f8f51b66d7e83014e5480b",
+        "revCount": 2324,
         "submodules": true,
         "type": "git",
         "url": "https://github.com/logos-messaging/logos-delivery"
       },
       "original": {
+        "rev": "34c197c5cdad1d5787f8f51b66d7e83014e5480b",
         "submodules": true,
         "type": "git",
         "url": "https://github.com/logos-messaging/logos-delivery"

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,7 @@
   inputs = {
     logos-module-builder.url = "github:logos-co/logos-module-builder";
     nix-bundle-lgx.url = "github:logos-co/nix-bundle-lgx";
-    logos-delivery.url = "git+https://github.com/logos-messaging/logos-delivery?submodules=1";
+    logos-delivery.url = "git+https://github.com/logos-messaging/logos-delivery?submodules=1&rev=c6e448a0bab95b61c85a224a91bb6a5f0d20002a";
     # Pin to the same zerokit logos-delivery uses so librln.dylib versions match
     zerokit.follows = "logos-delivery/zerokit";
   };

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,7 @@
   inputs = {
     logos-module-builder.url = "github:logos-co/logos-module-builder";
     nix-bundle-lgx.url = "github:logos-co/nix-bundle-lgx";
-    logos-delivery.url = "git+https://github.com/logos-messaging/logos-delivery?submodules=1&rev=c6e448a0bab95b61c85a224a91bb6a5f0d20002a";
+    logos-delivery.url = "git+https://github.com/logos-messaging/logos-delivery?submodules=1&rev=34c197c5cdad1d5787f8f51b66d7e83014e5480b";
     # Pin to the same zerokit logos-delivery uses so librln.dylib versions match
     zerokit.follows = "logos-delivery/zerokit";
   };

--- a/flake.nix
+++ b/flake.nix
@@ -42,20 +42,6 @@
               install_name_tool -change "$OLD_RLN" "@rpath/librln.dylib" lib/liblogosdelivery.dylib
             fi
           fi
-
-          # The integration test starts a real node, and liblogosdelivery loads
-          # libpq at runtime via dlopen with a bare name ("libpq.so.5"). The copy
-          # loaded during the test is the Nix store one (resolved via the store
-          # RPATH on the test binary), whose RUNPATH does not include libpq, so
-          # the dlopen fails. Add libpq's libdir to the loader search path for the
-          # test run. The main module build instead bundles libpq into $out/lib via
-          # postInstall; the tests run in place during buildPhase, so extending the
-          # search path is enough here.
-          LIBPQ_LIBDIR=$(pkg-config --variable=libdir libpq 2>/dev/null || true)
-          if [ -n "$LIBPQ_LIBDIR" ] && [ -d "$LIBPQ_LIBDIR" ]; then
-            export LD_LIBRARY_PATH="$LIBPQ_LIBDIR''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
-            export DYLD_LIBRARY_PATH="$LIBPQ_LIBDIR''${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}"
-          fi
         '';
       };
       # Bundle runtime libraries alongside the plugin.

--- a/flake.nix
+++ b/flake.nix
@@ -42,6 +42,20 @@
               install_name_tool -change "$OLD_RLN" "@rpath/librln.dylib" lib/liblogosdelivery.dylib
             fi
           fi
+
+          # The integration test starts a real node, and liblogosdelivery loads
+          # libpq at runtime via dlopen with a bare name ("libpq.so.5"). The copy
+          # loaded during the test is the Nix store one (resolved via the store
+          # RPATH on the test binary), whose RUNPATH does not include libpq, so
+          # the dlopen fails. Add libpq's libdir to the loader search path for the
+          # test run. The main module build instead bundles libpq into $out/lib via
+          # postInstall; the tests run in place during buildPhase, so extending the
+          # search path is enough here.
+          LIBPQ_LIBDIR=$(pkg-config --variable=libdir libpq 2>/dev/null || true)
+          if [ -n "$LIBPQ_LIBDIR" ] && [ -d "$LIBPQ_LIBDIR" ]; then
+            export LD_LIBRARY_PATH="$LIBPQ_LIBDIR''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+            export DYLD_LIBRARY_PATH="$LIBPQ_LIBDIR''${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}"
+          fi
         '';
       };
       # Bundle runtime libraries alongside the plugin.


### PR DESCRIPTION
Depends on https://github.com/logos-co/logos-module-builder/pull/99 (merged). That PR makes `mkLogosModuleTests` expose runtime dlopen deps on the loader path, so this PR drops the manual libpq workaround from the test `preConfigure` and bumps the module-builder lock to the merged commit.