### PR TITLE
chore: release v0.1.2

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
     "name": "delivery_module",
-    "version": "1.1.0",
+    "version": "0.1.2",
     "description": "Logos Delivery Module - High-level message-delivery API",
     "author": "Logos Core Team",
     "type": "core",


### PR DESCRIPTION
Bumps the module version to `0.1.2` per [`docs/versioning.md`](docs/versioning.md) — a patch release targeting Logos Testnet 1.

Also corrects the `metadata.json` version field, which had drifted from the `0.<testnet>.<patch>` policy (it read `1.1.0` while the latest tag is `v0.1.1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)