### PR TITLE
feat: expose node metrics via collectMetrics() for openmetrics scraping

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ The delivery module provides the following API methods (all synchronous, all ret
 - `getAvailableNodeInfoIDs()` - List queryable node info identifiers
 - `getNodeInfo(nodeInfoId: QString)` - Retrieve node info by identifier
 - `getAvailableConfigs()` - Retrieve available configuration parameter descriptions
+- `collectMetrics()` - Node metrics in the openmetrics `collectMetrics()` convention (see [Metrics](#metrics))
 
 ### Node Configuration (`createNode`)
 
@@ -196,6 +197,35 @@ carries a `QVariantList data` with positional values:
 - **`connectionStateChanged`** – node connectivity change
   - `data[0]` (`QString`): connection status
   - `data[1]` (`QString`): local timestamp (ISO-8601)
+
+### Metrics
+
+The node already aggregates Prometheus metrics internally (the same set exposed
+on `metricsServerPort`). `collectMetrics()` makes them scrapeable through the
+[`openmetrics`](https://github.com/logos-co/openmetrics-module) module without
+standing up a separate HTTP server: it reads the node's `"Metrics"` node-info
+attribute (Prometheus exposition text) and reshapes it into the openmetrics
+`collectMetrics()` convention:
+
+```json
+{
+  "metrics": [
+    { "name": "...", "type": "counter|gauge|histogram|summary", "help": "...", "value": 42, "labels": { "...": "..." } }
+  ]
+}
+```
+
+Implementing `collectMetrics()` (by convention — no registration needed) is all
+that is required to satisfy the openmetrics `metrics_source` interface. Point the
+`openmetrics` module at this one by name to scrape it:
+
+```bash
+logoscore --config-dir /tmp/om call openmetrics start '{"port":9090,"modules":["delivery_module"]}'
+curl http://localhost:9090/metrics   # every series carries module="delivery_module"
+```
+
+Before a node is created (or if the read fails) `collectMetrics()` returns an
+empty `{"metrics": []}` so a scrape never errors out on this module.
 
 ## Architecture
 

--- a/src/delivery_module_plugin.cpp
+++ b/src/delivery_module_plugin.cpp
@@ -1,11 +1,14 @@
 #include "delivery_module_plugin.h"
+#include <cctype>
 #include <cstdio>
 #include <ctime>
 #include <memory>
 #include <mutex>
 #include <optional>
 #include <semaphore>
+#include <sstream>
 #include <unordered_map>
+#include <vector>
 
 #include <nlohmann/json.hpp>
 #include <boost/beast/core/detail/base64.hpp>
@@ -37,6 +40,174 @@ int64_t currentTimestampNs() {
     struct timespec ts;
     clock_gettime(CLOCK_REALTIME, &ts);
     return static_cast<int64_t>(ts.tv_sec) * 1000000000LL + static_cast<int64_t>(ts.tv_nsec);
+}
+
+// --- Prometheus exposition text -> openmetrics collectMetrics() shape -------
+//
+// liblogosdelivery's "Metrics" node-info attribute returns Prometheus
+// exposition text (`defaultRegistry.toText()`). The openmetrics module instead
+// wants structured metrics: {"metrics":[{name,type,help,value,labels?}, ...]}.
+// These helpers translate the former into the latter. The translation is
+// deliberately lossless on names/values/labels and best-effort on type/help
+// (anything unknown degrades to type "unknown"/no help), since the openmetrics
+// renderer tolerates both.
+
+bool isKnownMetricType(const std::string& t) {
+    return t == "counter" || t == "gauge" || t == "histogram" || t == "summary";
+}
+
+bool isNameChar(char c) {
+    return std::isalnum(static_cast<unsigned char>(c)) || c == '_' || c == ':';
+}
+
+// Parse the contents of a `{...}` label set (braces excluded) into a JSON
+// object of string->string, honouring the exposition-format escapes
+// (`\\`, `\"`, `\n`) inside quoted values.
+nlohmann::json parsePromLabels(const std::string& s) {
+    nlohmann::json labels = nlohmann::json::object();
+    const size_t n = s.size();
+    size_t i = 0;
+    while (i < n) {
+        while (i < n && (s[i] == ' ' || s[i] == ',')) ++i;
+
+        size_t keyStart = i;
+        while (i < n && (std::isalnum(static_cast<unsigned char>(s[i])) || s[i] == '_')) ++i;
+        if (i == keyStart) break;
+        std::string key = s.substr(keyStart, i - keyStart);
+
+        while (i < n && s[i] == ' ') ++i;
+        if (i >= n || s[i] != '=') break;
+        ++i;
+        while (i < n && s[i] == ' ') ++i;
+        if (i >= n || s[i] != '"') break;
+        ++i; // opening quote
+
+        std::string value;
+        while (i < n && s[i] != '"') {
+            if (s[i] == '\\' && i + 1 < n) {
+                char c = s[i + 1];
+                if (c == 'n') value += '\n';
+                else if (c == '"') value += '"';
+                else if (c == '\\') value += '\\';
+                else { value += '\\'; value += c; }
+                i += 2;
+            } else {
+                value += s[i];
+                ++i;
+            }
+        }
+        if (i < n && s[i] == '"') ++i; // closing quote
+        labels[key] = value;
+    }
+    return labels;
+}
+
+nlohmann::json parsePrometheusText(const std::string& text) {
+    std::unordered_map<std::string, std::string> typeByFamily;
+    std::unordered_map<std::string, std::string> helpByFamily;
+
+    struct Sample {
+        std::string name;
+        std::string value;
+        nlohmann::json labels;
+    };
+    std::vector<Sample> samples;
+
+    std::istringstream iss(text);
+    std::string line;
+    while (std::getline(iss, line)) {
+        if (!line.empty() && line.back() == '\r') line.pop_back();
+
+        size_t start = line.find_first_not_of(" \t");
+        if (start == std::string::npos) continue; // blank line
+
+        if (line[start] == '#') {
+            // Metadata: `# HELP <name> <text>` or `# TYPE <name> <type>`.
+            std::istringstream ls(line.substr(start + 1));
+            std::string kind, name;
+            ls >> kind >> name;
+            if (kind == "HELP" && !name.empty()) {
+                std::string help;
+                std::getline(ls, help);
+                if (!help.empty() && help.front() == ' ') help.erase(0, 1);
+                helpByFamily[name] = help;
+            } else if (kind == "TYPE" && !name.empty()) {
+                std::string type;
+                ls >> type;
+                typeByFamily[name] = type;
+            }
+            continue;
+        }
+
+        // Sample: `<name>[{labels}] <value> [timestamp]`.
+        size_t p = start;
+        size_t nameStart = p;
+        while (p < line.size() && isNameChar(line[p])) ++p;
+        if (p == nameStart) continue;
+        std::string name = line.substr(nameStart, p - nameStart);
+
+        nlohmann::json labels = nlohmann::json::object();
+        if (p < line.size() && line[p] == '{') {
+            size_t close = line.find('}', p);
+            if (close == std::string::npos) continue;
+            labels = parsePromLabels(line.substr(p + 1, close - p - 1));
+            p = close + 1;
+        }
+
+        while (p < line.size() && (line[p] == ' ' || line[p] == '\t')) ++p;
+        size_t valStart = p;
+        while (p < line.size() && line[p] != ' ' && line[p] != '\t') ++p;
+        if (p == valStart) continue;
+        std::string value = line.substr(valStart, p - valStart);
+
+        samples.push_back({std::move(name), std::move(value), std::move(labels)});
+    }
+
+    // Map a sample series name back to its declared metric family so we can
+    // attach the family's TYPE/HELP. Counters/histograms/summaries expose
+    // suffixed samples (`_total`, `_bucket`, ...) under a base family name.
+    auto resolveFamily = [&](const std::string& series) -> std::string {
+        if (typeByFamily.count(series)) return series;
+        static const char* suffixes[] = {
+            "_total", "_bucket", "_sum", "_count", "_created", "_gsum", "_gcount"};
+        for (const char* suf : suffixes) {
+            std::string s(suf);
+            if (series.size() > s.size() &&
+                series.compare(series.size() - s.size(), s.size(), s) == 0) {
+                std::string base = series.substr(0, series.size() - s.size());
+                if (typeByFamily.count(base)) return base;
+            }
+        }
+        return series;
+    };
+
+    nlohmann::json metrics = nlohmann::json::array();
+    for (auto& sm : samples) {
+        const std::string family = resolveFamily(sm.name);
+
+        nlohmann::json metric;
+        metric["name"] = sm.name;
+
+        auto tIt = typeByFamily.find(family);
+        std::string type = (tIt != typeByFamily.end()) ? tIt->second : "unknown";
+        metric["type"] = isKnownMetricType(type) ? type : "unknown";
+
+        auto hIt = helpByFamily.find(family);
+        if (hIt != helpByFamily.end() && !hIt->second.empty()) {
+            metric["help"] = hIt->second;
+        }
+
+        // Pass the value through as a (numeric) string; the openmetrics
+        // renderer accepts numeric strings and avoids float round-tripping.
+        metric["value"] = sm.value;
+
+        if (!sm.labels.empty()) {
+            metric["labels"] = std::move(sm.labels);
+        }
+
+        metrics.push_back(std::move(metric));
+    }
+    return metrics;
 }
 } // namespace
 
@@ -467,4 +638,28 @@ StdLogosResult DeliveryModuleImpl::getAvailableConfigs() {
     }
 
     return outcome;
+}
+
+LogosMap DeliveryModuleImpl::collectMetrics()
+{
+    if (!deliveryCtx) {
+        // No node yet — report an empty but well-formed metric set so the
+        // openmetrics scraper renders nothing for this module rather than
+        // treating the scrape as a hard error.
+        return {{"metrics", nlohmann::json::array()}};
+    }
+
+    auto outcome = callApiRetValue(
+        "get_node_info",
+        CALLBACK_TIMEOUT,
+        bindApiCall(logosdelivery_get_node_info, deliveryCtx, "Metrics"));
+
+    if (!outcome.success || !outcome.value.is_string()) {
+        fprintf(stderr, "DeliveryModuleImpl: collectMetrics failed to read Metrics node info: %s\n",
+                outcome.error.c_str());
+        return {{"metrics", nlohmann::json::array()}};
+    }
+
+    nlohmann::json metrics = parsePrometheusText(outcome.value.get<std::string>());
+    return {{"metrics", std::move(metrics)}};
 }

--- a/src/delivery_module_plugin.h
+++ b/src/delivery_module_plugin.h
@@ -6,6 +6,7 @@
 #include <string>
 #include <vector>
 
+#include <logos_json.h>
 #include <logos_module_context.h>
 #include <logos_result.h>
 
@@ -164,6 +165,30 @@ public:
      * @brief Information about the available configuration parameters for `createNode`.
      */
     StdLogosResult getAvailableConfigs();
+
+    /**
+     * @brief Returns the node's metrics in the openmetrics `collectMetrics()`
+     *        convention so the `openmetrics` module can scrape this module.
+     *
+     * liblogosdelivery already aggregates Prometheus metrics in its global
+     * registry; the `"Metrics"` node-info attribute renders them as Prometheus
+     * exposition text. This method pulls that text and reshapes it into the
+     * structure the openmetrics scraper expects:
+     * @code{.json}
+     * { "metrics": [ { "name": ..., "type": ..., "help": ..., "value": ..., "labels": {...} } ] }
+     * @endcode
+     *
+     * Implementing this method (by convention, no registration needed) is what
+     * makes the module satisfy the openmetrics `metrics_source` interface; the
+     * scraper appends a `module="delivery_module"` label to every series.
+     *
+     * Always returns a well-formed `{"metrics": [...]}` map. When no node has
+     * been created yet, or the underlying read fails, the array is empty so a
+     * scrape never errors out on this module.
+     *
+     * @return LogosMap (JSON object) with a `metrics` array.
+     */
+    LogosMap collectMetrics();
 
     std::string name() const { return "delivery_module"; }
 

--- a/tests/test_delivery_module.cpp
+++ b/tests/test_delivery_module.cpp
@@ -252,6 +252,70 @@ LOGOS_TEST(getAvailableConfigs_returns_empty_on_ffi_failure) {
     LOGOS_ASSERT_FALSE(result.success);
 }
 
+// collectMetrics
+
+LOGOS_TEST(collectMetrics_returns_empty_without_createNode) {
+    auto t = LogosTestContext("delivery_module");
+    DeliveryModuleImpl impl;
+
+    LogosMap result = impl.collectMetrics();
+    LOGOS_ASSERT(result.contains("metrics"));
+    LOGOS_ASSERT(result["metrics"].is_array());
+    LOGOS_ASSERT(result["metrics"].empty());
+    // No context -> we must not even attempt the FFI read.
+    LOGOS_ASSERT_FALSE(t.cFunctionCalled("logosdelivery_get_node_info"));
+}
+
+LOGOS_TEST(collectMetrics_parses_prometheus_counter_and_gauge) {
+    auto t = LogosTestContext("delivery_module");
+    auto* impl = createInitializedImpl(t);
+
+    const char* promText =
+        "# HELP foo_requests Total requests handled\n"
+        "# TYPE foo_requests counter\n"
+        "foo_requests_total{shard=\"0\"} 42\n"
+        "# HELP bar_peers Connected peers\n"
+        "# TYPE bar_peers gauge\n"
+        "bar_peers 7\n";
+    t.mockCFunction("logosdelivery_get_node_info").returns(promText);
+
+    LogosMap result = impl->collectMetrics();
+    LOGOS_ASSERT(t.cFunctionCalled("logosdelivery_get_node_info"));
+    LOGOS_ASSERT(result.contains("metrics"));
+
+    auto& metrics = result["metrics"];
+    LOGOS_ASSERT(metrics.is_array());
+    LOGOS_ASSERT_EQ(metrics.size(), static_cast<size_t>(2));
+
+    // Counter sample keeps its full series name, family type/help, and labels.
+    LOGOS_ASSERT_EQ(metrics[0]["name"].get<std::string>(), std::string("foo_requests_total"));
+    LOGOS_ASSERT_EQ(metrics[0]["type"].get<std::string>(), std::string("counter"));
+    LOGOS_ASSERT_EQ(metrics[0]["help"].get<std::string>(), std::string("Total requests handled"));
+    LOGOS_ASSERT_EQ(metrics[0]["value"].get<std::string>(), std::string("42"));
+    LOGOS_ASSERT_EQ(metrics[0]["labels"]["shard"].get<std::string>(), std::string("0"));
+
+    // Gauge sample, no labels object emitted.
+    LOGOS_ASSERT_EQ(metrics[1]["name"].get<std::string>(), std::string("bar_peers"));
+    LOGOS_ASSERT_EQ(metrics[1]["type"].get<std::string>(), std::string("gauge"));
+    LOGOS_ASSERT_EQ(metrics[1]["value"].get<std::string>(), std::string("7"));
+    LOGOS_ASSERT_FALSE(metrics[1].contains("labels"));
+
+    delete impl;
+}
+
+LOGOS_TEST(collectMetrics_returns_empty_on_empty_registry) {
+    auto t = LogosTestContext("delivery_module");
+    auto* impl = createInitializedImpl(t);
+
+    t.mockCFunction("logosdelivery_get_node_info").returns("");
+    LogosMap result = impl->collectMetrics();
+
+    LOGOS_ASSERT(result["metrics"].is_array());
+    LOGOS_ASSERT(result["metrics"].empty());
+
+    delete impl;
+}
+
 // module name
 
 LOGOS_TEST(name_returns_delivery_module) {


### PR DESCRIPTION
## What & why

Makes the delivery module scrapeable by the [`openmetrics`](https://github.com/logos-co/openmetrics-module) module, which now supports any module implementing the `collectMetrics()` convention.

The node **already** aggregates Prometheus metrics in its global registry (the same set served on `metricsServerPort`) and renders them as exposition text via the `"Metrics"` node-info attribute (`waku_state_info.nim` → `defaultRegistry.toText()`). This PR just exposes them through the logoscore convention rather than requiring a separate HTTP server.

## How

- Add `LogosMap collectMetrics()` to `DeliveryModuleImpl`. Implementing this method (by convention, no registration) is all that's needed to satisfy openmetrics' `metrics_source` interface; the scraper appends a `module="delivery_module"` label to every series.
- It reads the existing `"Metrics"` node-info attribute over the current FFI (`logosdelivery_get_node_info`) and reshapes the Prometheus exposition text into the openmetrics `{"metrics":[{name,type,help,value,labels?}]}` shape via a small in-module parser.
- Values pass through as numeric strings (the openmetrics renderer accepts these), labels and HELP/TYPE metadata are preserved; unknown types degrade to `"unknown"`.
- Before a node exists, or on a read failure, returns an empty `{"metrics": []}` so a scrape never errors out on this module.

Scrape it:

```bash
logoscore --config-dir /tmp/om call openmetrics start '{"port":9090,"modules":["delivery_module"]}'
curl http://localhost:9090/metrics
```

## Tests

3 new unit tests (counter+gauge+labels parsing, empty-registry, no-context); full suite green (`nix build .#unit-tests`): 26 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)