### PR TITLE
docs: point run-node guide at logos.test fleet

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ values that differ from defaults need to be supplied.
 | Key                  | Type             | Default    | Description                              |
 |----------------------|------------------|------------|------------------------------------------|
 | `mode`               | string           | `"noMode"` | `"Core"`, `"Edge"`, or `"noMode"`        |
-| `preset`             | string           | `""`       | Network preset (`"twn"`, `"logos.dev"`)   |
+| `preset`             | string           | `""`       | Network preset (`"logos.test"`, `"logos.dev"`, `"twn"`) |
 | `clusterId`          | number (uint16)  | `0`        | Cluster identifier                       |
 | `entryNodes`         | array of string  | `[]`       | Bootstrap peers (enrtree / multiaddress) |
 | `relay`              | boolean          | `false`    | Enable relay protocol                    |
@@ -129,17 +129,19 @@ Using a `preset` populates cluster ID, entry nodes, sharding, RLN, and other
 network-specific defaults automatically. Individual keys supplied alongside a
 preset override the preset values.
 
-- `"twn"` – The RLN-protected Waku Network (cluster 1).
+- `"logos.test"` – Logos Test fleet (the default for running a node; mix
+  enabled, p2pReliability on, auto-shards, built-in bootstrap nodes).
 - `"logos.dev"` – Logos Dev Network (cluster 2, mix enabled, p2pReliability on,
   8 auto-shards, built-in bootstrap nodes).
+- `"twn"` – The RLN-protected Waku Network (cluster 1).
 
-Minimal example using the `logos.dev` preset:
+Minimal example using the default `logos.test` preset:
 
 ```json
 {
   "logLevel": "INFO",
   "mode": "Core",
-  "preset": "logos.dev"
+  "preset": "logos.test"
 }
 ```
 

--- a/conf/logos-test.json
+++ b/conf/logos-test.json
@@ -1,0 +1,4 @@
+{
+    "preset": "logos.test",
+    "logLevel":"DEBUG"
+}

--- a/docs/run-node.md
+++ b/docs/run-node.md
@@ -1,13 +1,20 @@
 # Run a delivery node
 
-Runs a delivery node (`logoscore` daemon + `delivery_module`) in Docker.
-There is no GUI or HTTP API — interaction is via the `logoscore` CLI.
+Runs a delivery node (`logoscore` daemon + `delivery_module`). There is no GUI
+or HTTP API — interaction is via the `logoscore` CLI. You can run it two ways:
 
-## Prerequisites
+- [With Docker](#with-docker) — quickest; everything runs in a container.
+- [Without Docker](#without-docker) — build and run natively with Nix.
+
+Both connect the node to the `logos.test` fleet by default.
+
+## With Docker
+
+### Prerequisites
 
 - Docker with Compose
 
-## Start
+### Start
 
 ```bash
 git clone https://github.com/logos-co/logos-delivery-module.git
@@ -18,7 +25,7 @@ docker compose up -d --build
 First build runs Nix and downloads release packages — allow ~30–45 min.
 Later starts are fast.
 
-## Boot the node
+### Boot the node
 
 The daemon is running; load the module and start the node:
 
@@ -34,18 +41,93 @@ Verify:
 docker exec logos-node logoscore status --json
 ```
 
-The node is now connected to the `logos.test` network. See
-[`query-node.md`](./query-node.md) to read its peer ID, ENR, and metrics.
-
-## Stop
+### Stop
 
 ```bash
 docker compose down
 ```
 
+## Without Docker
+
+Build the runtime and this module with Nix, then run the `logoscore` daemon
+directly on the host.
+
+### Prerequisites
+
+- [Nix](https://nixos.org/download.html) with flakes enabled
+- Linux or macOS
+
+### Build the runtime and module
+
+Build the `logoscore` CLI (the headless runtime) and the `lgpm` package
+manager from their flakes, then build and install this module's `.lgx`:
+
+```bash
+git clone https://github.com/logos-co/logos-delivery-module.git
+cd logos-delivery-module
+
+# Runtime + package manager
+nix build 'github:logos-co/logos-logoscore-cli' --out-link ./logos
+nix build 'github:logos-co/logos-package-manager#cli' -o lgpm
+
+# This module, built from the current checkout
+nix build '.#lgx' -o delivery-lgx
+
+# Seed the modules dir with the bundled capability module, then install
+mkdir -p modules
+cp -RL ./logos/modules/. ./modules/
+./lgpm/bin/lgpm --modules-dir ./modules --allow-unsigned install --file delivery-lgx/*.lgx
+```
+
+The first build compiles the whole runtime stack through Nix — allow
+~30–45 min. Later builds are fast.
+
+### Start the daemon
+
+Put `logoscore` on your `PATH` and start it in daemon mode pointed at
+`./modules`:
+
+```bash
+export PATH="$PWD/logos/bin:$PATH"
+logoscore -D -m ./modules > logs.txt &
+```
+
+### Boot the node
+
+```bash
+logoscore load-module delivery_module
+logoscore call delivery_module createNode @conf/logos-test.json
+logoscore call delivery_module start
+```
+
+Verify:
+
+```bash
+logoscore status
+```
+
+### Stop
+
+```bash
+logoscore stop
+```
+
+> For a fully pinned, build-from-this-commit walkthrough — plus notes on the
+> blocking Kademlia bootstrap in headless runs — see the
+> [runtime doc-test](../doctests/outputs/delivery-module-runtime.md).
+
 ## Configuration
 
-The node config is [`conf/logos-test.json`](../conf/logos-test.json), mounted
-into the container at `/conf`. It uses the `logos.test` network preset. Edit it
-and re-run the boot steps to change settings; available keys are documented in
-the [README](../README.md#node-configuration-createnode).
+The node config is [`conf/logos-test.json`](../conf/logos-test.json); it uses
+the `logos.test` network preset. With Docker it is mounted into the container
+at `/conf` (`@/conf/logos-test.json`); without Docker, pass the path directly
+(`@conf/logos-test.json`). Edit it and re-run the boot steps to change
+settings.
+
+To target the dev network instead, use
+[`conf/logos-dev.json`](../conf/logos-dev.json) (preset `logos.dev`). Available
+keys are documented in the
+[README](../README.md#node-configuration-createnode).
+
+The node is now connected to the `logos.test` network. See
+[`query-node.md`](./query-node.md) to read its peer ID, ENR, and metrics.

--- a/docs/run-node.md
+++ b/docs/run-node.md
@@ -24,7 +24,7 @@ The daemon is running; load the module and start the node:
 
 ```bash
 docker exec logos-node logoscore load-module delivery_module --json
-docker exec logos-node logoscore call delivery_module createNode @/conf/logos-dev.json --json
+docker exec logos-node logoscore call delivery_module createNode @/conf/logos-test.json --json
 docker exec logos-node logoscore call delivery_module start --json
 ```
 
@@ -34,7 +34,7 @@ Verify:
 docker exec logos-node logoscore status --json
 ```
 
-The node is now connected to the `logos.dev` network. See
+The node is now connected to the `logos.test` network. See
 [`query-node.md`](./query-node.md) to read its peer ID, ENR, and metrics.
 
 ## Stop
@@ -45,7 +45,7 @@ docker compose down
 
 ## Configuration
 
-The node config is [`conf/logos-dev.json`](../conf/logos-dev.json), mounted
-into the container at `/conf`. It uses the `logos.dev` network preset. Edit it
+The node config is [`conf/logos-test.json`](../conf/logos-test.json), mounted
+into the container at `/conf`. It uses the `logos.test` network preset. Edit it
 and re-run the boot steps to change settings; available keys are documented in
 the [README](../README.md#node-configuration-createnode).


### PR DESCRIPTION
Updates the run-a-node instruction to use the `logos.test` fleet instead of `logos.dev`.

- `docs/run-node.md`: `createNode` now references `@/conf/logos-test.json`; network name references updated to `logos.test`.
- Adds `conf/logos-test.json` (preset `logos.test`), mounted into the container at `/conf` via the existing `./conf:/conf:ro` bind.

`conf/logos-dev.json` is left in place for anyone still targeting the dev network.

🤖 Generated with [Claude Code](https://claude.com/claude-code)