### PR TITLE
docs: add prebuilt-binary run path to run-node guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ The delivery module provides the following API methods (all synchronous, all ret
 - `getAvailableNodeInfoIDs()` - List queryable node info identifiers
 - `getNodeInfo(nodeInfoId: QString)` - Retrieve node info by identifier
 - `getAvailableConfigs()` - Retrieve available configuration parameter descriptions
-- `collectOpenMetricsText()` - Node metrics as OpenMetrics/Prometheus text for the `openmetrics` module (see [Metrics](#metrics))
+- `collectOpenMetricsText()` - Node metrics as OpenMetrics/Prometheus text for the `openmetrics` module (see [docs/run-node.md → Metrics](docs/run-node.md#metrics))
 
 ### Node Configuration (`createNode`)
 
@@ -202,26 +202,11 @@ carries a `QVariantList data` with positional values:
 
 ### Metrics
 
-The node already aggregates Prometheus metrics internally (the same set exposed
-on `metricsServerPort`, rendered behind the `"Metrics"` node-info attribute).
-`collectOpenMetricsText()` hands that exposition text back **verbatim** so the
-[`openmetrics`](https://github.com/logos-co/openmetrics-module) module can scrape
-this module without standing up a separate HTTP server — no in-module parsing or
-reshaping. The openmetrics scraper parses the text, injects a
-`module="delivery_module"` label on every series, and merges it with other
-modules.
-
-Point the `openmetrics` module at this one by name, selecting the text-source
-convention with `"format": "text"`:
-
-```bash
-logoscore --config-dir /tmp/om call openmetrics start \
-  '{"port":9090,"modules":[{"name":"delivery_module","format":"text"}]}'
-curl http://localhost:9090/metrics   # every series carries module="delivery_module"
-```
-
-Before a node is created (or if the read fails) `collectOpenMetricsText()`
-returns an empty document so a scrape never errors out on this module.
+`collectOpenMetricsText()` returns the node's internal Prometheus metrics as
+OpenMetrics/Prometheus exposition text for the
+[`openmetrics`](https://github.com/logos-co/openmetrics-module) module to scrape.
+For how to wire up `openmetrics` and scrape a running node, see
+[Running a node → Metrics](docs/run-node.md#metrics).
 
 ## Architecture
 

--- a/docs/run-node.md
+++ b/docs/run-node.md
@@ -64,44 +64,23 @@ need three CLIs from the Logos releases:
 All three are published for Linux (`x86_64` / `aarch64`) and macOS (Apple
 Silicon / `aarch64`).
 
-### Get the tools onto your `PATH`
+### Install the tools
 
-These helpers resolve and download each tool's **latest** release (the binaries
-currently ship as pre-releases, so we read the newest tag rather than pin one):
-
-```bash
-latest() { curl -fsSL "https://api.github.com/repos/logos-co/$1/releases" | grep -m1 '"tag_name":' | cut -d'"' -f4; }
-dl()     { curl -fsSL "https://github.com/logos-co/$1/releases/download/$(latest "$1")/$2"; }
-```
-
-**Linux** (each tarball holds one AppImage; AppImages need FUSE — in a
-container/headless host without it, `export APPIMAGE_EXTRACT_AND_RUN=1`):
+This downloads the newest `logoscore`, `lgpd`, and `lgpm` for your OS/arch into
+`./bin` (the binaries currently ship as pre-releases, so the script resolves the
+latest release of each):
 
 ```bash
-arch=x86_64        # or: aarch64
-dl logos-logoscore-cli      "logoscore-${arch}-linux.tar.gz" | tar xz
-dl logos-package-downloader "lgpd-${arch}-linux.tar.gz"      | tar xz
-dl logos-package-manager    "lgpm-${arch}-linux.tar.gz"      | tar xz
-mkdir -p bin
-for t in logoscore lgpd lgpm; do chmod +x "${t}-${arch}.AppImage"; ln -sf "$PWD/${t}-${arch}.AppImage" "bin/$t"; done
+curl -fsSL https://raw.githubusercontent.com/logos-co/logos-delivery-module/master/scripts/install-node-tools.sh | sh
 export PATH="$PWD/bin:$PATH"
-```
-
-**macOS (Apple Silicon):**
-
-```bash
-dl logos-logoscore-cli      "logoscore-aarch64-macos.tar.gz" | tar xz
-dl logos-package-downloader "lgpd-aarch64-macos.tar.gz"      | tar xz
-dl logos-package-manager    "lgpm-aarch64-macos.tar.gz"      | tar xz
-export PATH="$PWD/logoscore-aarch64-macos/bin:$PWD/lgpd-aarch64-macos/bin:$PWD/lgpm-aarch64-macos/bin:$PATH"
 ```
 
 ### Download the module and boot the node
 
 ```bash
 # Fetch delivery_module from the Logos catalog, then install it into ./modules
+mkdir -p packages modules
 lgpd download delivery_module --output ./packages
-mkdir -p modules
 lgpm install --dir ./packages --modules-dir ./modules
 
 # logos.test node config

--- a/docs/run-node.md
+++ b/docs/run-node.md
@@ -5,7 +5,7 @@ or HTTP API — interaction is via the `logoscore` CLI. You can run it three way
 
 - [With Docker](#with-docker) — quickest; everything runs in a container.
 - [Prebuilt binaries](#without-docker-prebuilt-binaries) — download release
-  binaries, nothing to build (Linux only).
+  binaries, nothing to build (Linux and macOS).
 - [Build with Nix](#without-docker-build-with-nix) — build from source on any
   platform.
 
@@ -52,62 +52,76 @@ docker compose down
 
 ## Without Docker: prebuilt binaries
 
-Download the `logoscore` daemon, the `lgpm` package manager, and this module's
-prebuilt `.lgx` from their GitHub releases — nothing to build, no repository
-clone required. Each Logos module is published from
-[`logos-modules-release`](https://github.com/logos-co/logos-modules-release)
-under a per-module tag (e.g. `delivery_module-v0.1.3`).
+Run a node from released binaries — nothing to build, no repository clone. You
+need three CLIs from the Logos releases:
 
-> Published only for Linux (`x86_64` / `aarch64`). On macOS, use Docker or the
-> Nix build below — the `logoscore` daemon is released only for Linux.
->
-> The `logos.test` preset requires `delivery_module` **≥ 0.1.3**; earlier builds
-> only know `twn` and `logos.dev`.
+- **`logoscore`** — the node daemon ([logos-logoscore-cli](https://github.com/logos-co/logos-logoscore-cli))
+- **`lgpd`** — package downloader, fetches modules from the Logos catalog
+  ([logos-package-downloader](https://github.com/logos-co/logos-package-downloader))
+- **`lgpm`** — package manager, installs them locally
+  ([logos-package-manager](https://github.com/logos-co/logos-package-manager))
+
+All three are published for Linux (`x86_64` / `aarch64`) and macOS (Apple
+Silicon / `aarch64`).
+
+### Get the tools onto your `PATH`
+
+The release tags below are the current pre-releases — bump them to the newest
+from each repo's releases page if needed.
+
+**Linux** (each tarball holds one AppImage; AppImages need FUSE — in a
+container/headless host without it, `export APPIMAGE_EXTRACT_AND_RUN=1`):
 
 ```bash
 arch=x86_64        # or: aarch64
-
-# logoscore daemon (AppImage) — latest release
-curl -L -o logoscore \
-  "https://github.com/logos-co/logos-logoscore-cli/releases/latest/download/logoscore-${arch}-linux.AppImage"
-chmod +x logoscore
-
-# lgpm package manager (an AppImage inside the tarball)
-curl -L "https://github.com/logos-co/logos-package-manager/releases/download/pre-release-05b2cf8-7/lgpm-${arch}-linux.tar.gz" | tar xz
-chmod +x "lgpm-${arch}.AppImage"
-
-# This module, prebuilt (needs >= 0.1.3 for the logos.test preset)
-ver=0.1.3
-curl -L -o "delivery_module-${ver}.lgx" \
-  "https://github.com/logos-co/logos-modules-release/releases/download/delivery_module-v${ver}/delivery_module-${ver}.lgx"
-
-# Install the module into ./modules
-mkdir -p modules
-"./lgpm-${arch}.AppImage" --modules-dir ./modules --allow-unsigned install --file "delivery_module-${ver}.lgx"
+curl -fsSL "https://github.com/logos-co/logos-logoscore-cli/releases/download/pre-release-8002477-4/logoscore-${arch}-linux.tar.gz" | tar xz
+curl -fsSL "https://github.com/logos-co/logos-package-downloader/releases/download/pre-release-99d70db-7/lgpd-${arch}-linux.tar.gz" | tar xz
+curl -fsSL "https://github.com/logos-co/logos-package-manager/releases/download/pre-release-05b2cf8-7/lgpm-${arch}-linux.tar.gz" | tar xz
+mkdir -p bin
+for t in logoscore lgpd lgpm; do chmod +x "${t}-${arch}.AppImage"; ln -sf "$PWD/${t}-${arch}.AppImage" "bin/$t"; done
+export PATH="$PWD/bin:$PATH"
 ```
 
-Write the node config and boot the node (the daemon binds `capability_module`
-automatically, so the `./modules` dir only needs `delivery_module`):
+**macOS (Apple Silicon):**
 
 ```bash
+curl -fsSL "https://github.com/logos-co/logos-logoscore-cli/releases/download/pre-release-8002477-4/logoscore-aarch64-macos.tar.gz" | tar xz
+curl -fsSL "https://github.com/logos-co/logos-package-downloader/releases/download/pre-release-99d70db-7/lgpd-aarch64-macos.tar.gz" | tar xz
+curl -fsSL "https://github.com/logos-co/logos-package-manager/releases/download/pre-release-05b2cf8-7/lgpm-aarch64-macos.tar.gz" | tar xz
+export PATH="$PWD/logoscore-aarch64-macos/bin:$PWD/lgpd-aarch64-macos/bin:$PWD/lgpm-aarch64-macos/bin:$PATH"
+```
+
+### Download the module and boot the node
+
+```bash
+# Fetch delivery_module from the Logos catalog, then install it into ./modules
+lgpd download delivery_module --output ./packages
+mkdir -p modules
+lgpm install --dir ./packages --modules-dir ./modules
+
+# logos.test node config
 cat > logos-test.json <<'JSON'
 { "preset": "logos.test", "logLevel": "DEBUG" }
 JSON
 
-./logoscore -D -m ./modules > logs.txt &
-./logoscore load-module delivery_module
-./logoscore call delivery_module createNode @logos-test.json
-./logoscore call delivery_module start
+# Run the daemon (it binds capability_module automatically, so ./modules only
+# needs delivery_module), then boot the node
+logoscore -D -m ./modules > logs.txt &
+logoscore load-module delivery_module
+logoscore call delivery_module createNode @logos-test.json
+logoscore call delivery_module start
 ```
 
-Verify with `./logoscore status`; stop with `./logoscore stop`.
+Verify with `logoscore status`; stop with `logoscore stop`.
 
-> Both `lgpm` and the module are pinned to specific tags above (neither has a
-> rolling `latest`). Bump `ver` to the newest `delivery_module-*` tag from the
-> [logos-modules-release releases](https://github.com/logos-co/logos-modules-release/releases),
-> and `lgpm` to the newest from the
-> [package-manager releases](https://github.com/logos-co/logos-package-manager/releases),
-> as needed.
+> `lgpd download delivery_module` pulls the newest version from the Logos
+> catalog — `lgpd`'s built-in repository is
+> [`logos-modules-release`](https://github.com/logos-co/logos-modules-release).
+> The `logos.test` preset needs `delivery_module` **≥ 0.1.3**; earlier builds
+> only know `twn` and `logos.dev`. (You can also grab a specific `.lgx`
+> straight from the
+> [release page](https://github.com/logos-co/logos-modules-release/releases)
+> and skip `lgpd` — `lgpm install --file <path>` then takes it.)
 
 ## Without Docker: build with Nix
 

--- a/docs/run-node.md
+++ b/docs/run-node.md
@@ -66,17 +66,22 @@ Silicon / `aarch64`).
 
 ### Get the tools onto your `PATH`
 
-The release tags below are the current pre-releases — bump them to the newest
-from each repo's releases page if needed.
+These helpers resolve and download each tool's **latest** release (the binaries
+currently ship as pre-releases, so we read the newest tag rather than pin one):
+
+```bash
+latest() { curl -fsSL "https://api.github.com/repos/logos-co/$1/releases" | grep -m1 '"tag_name":' | cut -d'"' -f4; }
+dl()     { curl -fsSL "https://github.com/logos-co/$1/releases/download/$(latest "$1")/$2"; }
+```
 
 **Linux** (each tarball holds one AppImage; AppImages need FUSE — in a
 container/headless host without it, `export APPIMAGE_EXTRACT_AND_RUN=1`):
 
 ```bash
 arch=x86_64        # or: aarch64
-curl -fsSL "https://github.com/logos-co/logos-logoscore-cli/releases/download/pre-release-8002477-4/logoscore-${arch}-linux.tar.gz" | tar xz
-curl -fsSL "https://github.com/logos-co/logos-package-downloader/releases/download/pre-release-99d70db-7/lgpd-${arch}-linux.tar.gz" | tar xz
-curl -fsSL "https://github.com/logos-co/logos-package-manager/releases/download/pre-release-05b2cf8-7/lgpm-${arch}-linux.tar.gz" | tar xz
+dl logos-logoscore-cli      "logoscore-${arch}-linux.tar.gz" | tar xz
+dl logos-package-downloader "lgpd-${arch}-linux.tar.gz"      | tar xz
+dl logos-package-manager    "lgpm-${arch}-linux.tar.gz"      | tar xz
 mkdir -p bin
 for t in logoscore lgpd lgpm; do chmod +x "${t}-${arch}.AppImage"; ln -sf "$PWD/${t}-${arch}.AppImage" "bin/$t"; done
 export PATH="$PWD/bin:$PATH"
@@ -85,9 +90,9 @@ export PATH="$PWD/bin:$PATH"
 **macOS (Apple Silicon):**
 
 ```bash
-curl -fsSL "https://github.com/logos-co/logos-logoscore-cli/releases/download/pre-release-8002477-4/logoscore-aarch64-macos.tar.gz" | tar xz
-curl -fsSL "https://github.com/logos-co/logos-package-downloader/releases/download/pre-release-99d70db-7/lgpd-aarch64-macos.tar.gz" | tar xz
-curl -fsSL "https://github.com/logos-co/logos-package-manager/releases/download/pre-release-05b2cf8-7/lgpm-aarch64-macos.tar.gz" | tar xz
+dl logos-logoscore-cli      "logoscore-aarch64-macos.tar.gz" | tar xz
+dl logos-package-downloader "lgpd-aarch64-macos.tar.gz"      | tar xz
+dl logos-package-manager    "lgpm-aarch64-macos.tar.gz"      | tar xz
 export PATH="$PWD/logoscore-aarch64-macos/bin:$PWD/lgpd-aarch64-macos/bin:$PWD/lgpm-aarch64-macos/bin:$PATH"
 ```
 
@@ -113,15 +118,6 @@ logoscore call delivery_module start
 ```
 
 Verify with `logoscore status`; stop with `logoscore stop`.
-
-> `lgpd download delivery_module` pulls the newest version from the Logos
-> catalog — `lgpd`'s built-in repository is
-> [`logos-modules-release`](https://github.com/logos-co/logos-modules-release).
-> The `logos.test` preset needs `delivery_module` **≥ 0.1.3**; earlier builds
-> only know `twn` and `logos.dev`. (You can also grab a specific `.lgx`
-> straight from the
-> [release page](https://github.com/logos-co/logos-modules-release/releases)
-> and skip `lgpd` — `lgpm install --file <path>` then takes it.)
 
 ## Without Docker: build with Nix
 
@@ -208,3 +204,29 @@ keys are documented in the
 
 The node is now connected to the `logos.test` network. See
 [`query-node.md`](./query-node.md) to read its peer ID, ENR, and metrics.
+
+## Metrics
+
+The node already aggregates Prometheus metrics internally (the same set exposed
+on `metricsServerPort`, rendered behind the `"Metrics"` node-info attribute).
+`collectOpenMetricsText()` hands that exposition text back **verbatim** so the
+[`openmetrics`](https://github.com/logos-co/openmetrics-module) module can scrape
+this module without standing up a separate HTTP server — no in-module parsing or
+reshaping. The openmetrics scraper parses the text, injects a
+`module="delivery_module"` label on every series, and merges it with other
+modules.
+
+Point the `openmetrics` module at this one by name, selecting the text-source
+convention with `"format": "text"`:
+
+```bash
+logoscore --config-dir /tmp/om call openmetrics start \
+  '{"port":9090,"modules":[{"name":"delivery_module","format":"text"}]}'
+curl http://localhost:9090/metrics   # every series carries module="delivery_module"
+```
+
+Before a node is created (or if the read fails) `collectOpenMetricsText()`
+returns an empty document so a scrape never errors out on this module.
+
+For a one-off read without the `openmetrics` module, the raw exposition text is
+also available via `getNodeInfo Metrics` — see [`query-node.md`](./query-node.md).

--- a/docs/run-node.md
+++ b/docs/run-node.md
@@ -54,11 +54,15 @@ docker compose down
 
 Download the `logoscore` daemon, the `lgpm` package manager, and this module's
 prebuilt `.lgx` from their GitHub releases — nothing to build, no repository
-clone required. The module package ([`logos-modules`](https://github.com/logos-co/logos-modules)
-releases) bundles every Logos module, including `delivery_module`.
+clone required. Each Logos module is published from
+[`logos-modules-release`](https://github.com/logos-co/logos-modules-release)
+under a per-module tag (e.g. `delivery_module-v0.1.3`).
 
 > Published only for Linux (`x86_64` / `aarch64`). On macOS, use Docker or the
 > Nix build below — the `logoscore` daemon is released only for Linux.
+>
+> The `logos.test` preset requires `delivery_module` **≥ 0.1.3**; earlier builds
+> only know `twn` and `logos.dev`.
 
 ```bash
 arch=x86_64        # or: aarch64
@@ -72,13 +76,14 @@ chmod +x logoscore
 curl -L "https://github.com/logos-co/logos-package-manager/releases/download/pre-release-05b2cf8-7/lgpm-${arch}-linux.tar.gz" | tar xz
 chmod +x "lgpm-${arch}.AppImage"
 
-# This module, prebuilt — latest logos-modules release
-curl -L -o delivery_module.lgx \
-  "https://github.com/logos-co/logos-modules/releases/latest/download/delivery_module.lgx"
+# This module, prebuilt (needs >= 0.1.3 for the logos.test preset)
+ver=0.1.3
+curl -L -o "delivery_module-${ver}.lgx" \
+  "https://github.com/logos-co/logos-modules-release/releases/download/delivery_module-v${ver}/delivery_module-${ver}.lgx"
 
 # Install the module into ./modules
 mkdir -p modules
-"./lgpm-${arch}.AppImage" --modules-dir ./modules --allow-unsigned install --file delivery_module.lgx
+"./lgpm-${arch}.AppImage" --modules-dir ./modules --allow-unsigned install --file "delivery_module-${ver}.lgx"
 ```
 
 Write the node config and boot the node (the daemon binds `capability_module`
@@ -97,10 +102,12 @@ JSON
 
 Verify with `./logoscore status`; stop with `./logoscore stop`.
 
-> `lgpm` has no stable release yet, so its URL is pinned to a specific
-> pre-release tag — bump it to the newest from the
-> [package-manager releases](https://github.com/logos-co/logos-package-manager/releases)
-> if needed.
+> Both `lgpm` and the module are pinned to specific tags above (neither has a
+> rolling `latest`). Bump `ver` to the newest `delivery_module-*` tag from the
+> [logos-modules-release releases](https://github.com/logos-co/logos-modules-release/releases),
+> and `lgpm` to the newest from the
+> [package-manager releases](https://github.com/logos-co/logos-package-manager/releases),
+> as needed.
 
 ## Without Docker: build with Nix
 

--- a/docs/run-node.md
+++ b/docs/run-node.md
@@ -66,9 +66,9 @@ Silicon / `aarch64`).
 
 ### Install the tools
 
-This downloads the newest `logoscore`, `lgpd`, and `lgpm` for your OS/arch into
-`./bin` (the binaries currently ship as pre-releases, so the script resolves the
-latest release of each):
+This downloads `logoscore`, `lgpd`, and `lgpm` for your OS/arch into `./bin`
+(the script pins a known-good release of each — bump the `*_TAG` values in it to
+move to newer builds):
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/logos-co/logos-delivery-module/master/scripts/install-node-tools.sh | sh

--- a/docs/run-node.md
+++ b/docs/run-node.md
@@ -1,12 +1,15 @@
 # Run a delivery node
 
 Runs a delivery node (`logoscore` daemon + `delivery_module`). There is no GUI
-or HTTP API — interaction is via the `logoscore` CLI. You can run it two ways:
+or HTTP API — interaction is via the `logoscore` CLI. You can run it three ways:
 
 - [With Docker](#with-docker) — quickest; everything runs in a container.
-- [Without Docker](#without-docker) — build and run natively with Nix.
+- [Prebuilt binaries](#without-docker-prebuilt-binaries) — download release
+  binaries, nothing to build (Linux only).
+- [Build with Nix](#without-docker-build-with-nix) — build from source on any
+  platform.
 
-Both connect the node to the `logos.test` fleet by default.
+All three connect the node to the `logos.test` fleet by default.
 
 ## With Docker
 
@@ -47,7 +50,59 @@ docker exec logos-node logoscore status --json
 docker compose down
 ```
 
-## Without Docker
+## Without Docker: prebuilt binaries
+
+Download the `logoscore` daemon, the `lgpm` package manager, and this module's
+prebuilt `.lgx` from their GitHub releases — nothing to build, no repository
+clone required. The module package ([`logos-modules`](https://github.com/logos-co/logos-modules)
+releases) bundles every Logos module, including `delivery_module`.
+
+> Published only for Linux (`x86_64` / `aarch64`). On macOS, use Docker or the
+> Nix build below — the `logoscore` daemon is released only for Linux.
+
+```bash
+arch=x86_64        # or: aarch64
+
+# logoscore daemon (AppImage) — latest release
+curl -L -o logoscore \
+  "https://github.com/logos-co/logos-logoscore-cli/releases/latest/download/logoscore-${arch}-linux.AppImage"
+chmod +x logoscore
+
+# lgpm package manager (an AppImage inside the tarball)
+curl -L "https://github.com/logos-co/logos-package-manager/releases/download/pre-release-05b2cf8-7/lgpm-${arch}-linux.tar.gz" | tar xz
+chmod +x "lgpm-${arch}.AppImage"
+
+# This module, prebuilt — latest logos-modules release
+curl -L -o delivery_module.lgx \
+  "https://github.com/logos-co/logos-modules/releases/latest/download/delivery_module.lgx"
+
+# Install the module into ./modules
+mkdir -p modules
+"./lgpm-${arch}.AppImage" --modules-dir ./modules --allow-unsigned install --file delivery_module.lgx
+```
+
+Write the node config and boot the node (the daemon binds `capability_module`
+automatically, so the `./modules` dir only needs `delivery_module`):
+
+```bash
+cat > logos-test.json <<'JSON'
+{ "preset": "logos.test", "logLevel": "DEBUG" }
+JSON
+
+./logoscore -D -m ./modules > logs.txt &
+./logoscore load-module delivery_module
+./logoscore call delivery_module createNode @logos-test.json
+./logoscore call delivery_module start
+```
+
+Verify with `./logoscore status`; stop with `./logoscore stop`.
+
+> `lgpm` has no stable release yet, so its URL is pinned to a specific
+> pre-release tag — bump it to the newest from the
+> [package-manager releases](https://github.com/logos-co/logos-package-manager/releases)
+> if needed.
+
+## Without Docker: build with Nix
 
 Build the runtime and this module with Nix, then run the `logoscore` daemon
 directly on the host.
@@ -118,11 +173,12 @@ logoscore stop
 
 ## Configuration
 
-The node config is [`conf/logos-test.json`](../conf/logos-test.json); it uses
-the `logos.test` network preset. With Docker it is mounted into the container
-at `/conf` (`@/conf/logos-test.json`); without Docker, pass the path directly
-(`@conf/logos-test.json`). Edit it and re-run the boot steps to change
-settings.
+The node config is just the `logos.test` network preset. The repo ships it as
+[`conf/logos-test.json`](../conf/logos-test.json): with Docker it is mounted
+into the container at `/conf` (`@/conf/logos-test.json`); with the Nix build,
+pass the path directly (`@conf/logos-test.json`). The prebuilt-binaries path
+above writes the same config inline as `logos-test.json` so no clone is needed.
+Edit it and re-run the boot steps to change settings.
 
 To target the dev network instead, use
 [`conf/logos-dev.json`](../conf/logos-dev.json) (preset `logos.dev`). Available

--- a/scripts/install-node-tools.sh
+++ b/scripts/install-node-tools.sh
@@ -1,10 +1,15 @@
 #!/bin/sh
 # Download the Logos node CLIs — logoscore, lgpd, lgpm — into ./bin.
 #
-# Resolves each tool's newest release (they currently ship as pre-releases) and
-# unpacks the build for the host OS/arch. Works on Linux (x86_64/aarch64) and
-# macOS (Apple Silicon). After it finishes:  export PATH="$PWD/bin:$PATH"
+# Unpacks a pinned release of each tool for the host OS/arch. Works on Linux
+# (x86_64/aarch64) and macOS (Apple Silicon). To move to newer builds, bump the
+# *_TAG values below. After it finishes:  export PATH="$PWD/bin:$PATH"
 set -eu
+
+# Pinned tool releases (latest at time of writing).
+LOGOSCORE_TAG=pre-release-8002477-4
+LGPD_TAG=pre-release-99d70db-7
+LGPM_TAG=pre-release-05b2cf8-7
 
 os=$(uname -s | tr '[:upper:]' '[:lower:]')
 if [ "$os" = darwin ]; then os=macos; fi
@@ -19,17 +24,9 @@ esac
 bin="$PWD/bin"
 mkdir -p "$bin"
 
-# newest release tag for a logos-co repo (includes pre-releases)
-latest() {
-  curl -fsSL "https://api.github.com/repos/logos-co/$1/releases" \
-    | grep -m1 '"tag_name":' | cut -d'"' -f4
-}
-
-# fetch <repo> <tool>: download <tool>-<arch>-<os>.tar.gz and expose ./bin/<tool>
+# fetch <repo> <tool> <tag>: download <tool>-<arch>-<os>.tar.gz, expose ./bin/<tool>
 fetch() {
-  repo=$1; tool=$2
-  tag=$(latest "$repo")
-  [ -n "$tag" ] || { echo "no release found for $repo" >&2; exit 1; }
+  repo=$1; tool=$2; tag=$3
   echo "  $tool ($tag)"
   tmp=$(mktemp -d)
   curl -fsSL "https://github.com/logos-co/$repo/releases/download/$tag/$tool-$arch-$os.tar.gz" \
@@ -51,9 +48,9 @@ fetch() {
 }
 
 echo "Installing Logos node tools for $os/$arch into $bin ..."
-fetch logos-logoscore-cli      logoscore
-fetch logos-package-downloader lgpd
-fetch logos-package-manager    lgpm
+fetch logos-logoscore-cli      logoscore "$LOGOSCORE_TAG"
+fetch logos-package-downloader lgpd      "$LGPD_TAG"
+fetch logos-package-manager    lgpm      "$LGPM_TAG"
 echo
 echo "Done. Put them on your PATH:"
 echo "  export PATH=\"$bin:\$PATH\""

--- a/scripts/install-node-tools.sh
+++ b/scripts/install-node-tools.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+# Download the Logos node CLIs — logoscore, lgpd, lgpm — into ./bin.
+#
+# Resolves each tool's newest release (they currently ship as pre-releases) and
+# unpacks the build for the host OS/arch. Works on Linux (x86_64/aarch64) and
+# macOS (Apple Silicon). After it finishes:  export PATH="$PWD/bin:$PATH"
+set -eu
+
+os=$(uname -s | tr '[:upper:]' '[:lower:]')
+if [ "$os" = darwin ]; then os=macos; fi
+arch=$(uname -m)
+if [ "$arch" = arm64 ]; then arch=aarch64; fi
+
+case "$os" in
+  linux|macos) ;;
+  *) echo "unsupported OS: $os (Linux/macOS only)" >&2; exit 1 ;;
+esac
+
+bin="$PWD/bin"
+mkdir -p "$bin"
+
+# newest release tag for a logos-co repo (includes pre-releases)
+latest() {
+  curl -fsSL "https://api.github.com/repos/logos-co/$1/releases" \
+    | grep -m1 '"tag_name":' | cut -d'"' -f4
+}
+
+# fetch <repo> <tool>: download <tool>-<arch>-<os>.tar.gz and expose ./bin/<tool>
+fetch() {
+  repo=$1; tool=$2
+  tag=$(latest "$repo")
+  [ -n "$tag" ] || { echo "no release found for $repo" >&2; exit 1; }
+  echo "  $tool ($tag)"
+  tmp=$(mktemp -d)
+  curl -fsSL "https://github.com/logos-co/$repo/releases/download/$tag/$tool-$arch-$os.tar.gz" \
+    | tar xz -C "$tmp"
+  if [ "$os" = macos ]; then
+    # tarball is <tool>-<arch>-macos/{bin,lib,...}; the binary finds its bundled
+    # libs/modules relative to its real path, so wrap it (a symlink would break
+    # that resolution) rather than linking.
+    rm -rf "$bin/$tool-$arch-macos"
+    mv "$tmp/$tool-$arch-macos" "$bin/"
+    printf '#!/bin/sh\nexec "%s/%s-%s-macos/bin/%s" "$@"\n' "$bin" "$tool" "$arch" "$tool" > "$bin/$tool"
+    chmod +x "$bin/$tool"
+  else
+    # tarball is a single <tool>-<arch>.AppImage
+    mv "$tmp/$tool-$arch.AppImage" "$bin/$tool"
+    chmod +x "$bin/$tool"
+  fi
+  rm -rf "$tmp"
+}
+
+echo "Installing Logos node tools for $os/$arch into $bin ..."
+fetch logos-logoscore-cli      logoscore
+fetch logos-package-downloader lgpd
+fetch logos-package-manager    lgpm
+echo
+echo "Done. Put them on your PATH:"
+echo "  export PATH=\"$bin:\$PATH\""


### PR DESCRIPTION
Adds a third way to run a delivery node — using **prebuilt release binaries**, no build required — alongside the existing Docker and Nix paths.

Answering the question directly: **yes**, you can avoid building. All three pieces are published as release binaries:
- `logoscore` daemon — AppImage from [logos-logoscore-cli releases](https://github.com/logos-co/logos-logoscore-cli/releases) (`latest`)
- `lgpm` package manager — AppImage (tarball) from [logos-package-manager releases](https://github.com/logos-co/logos-package-manager/releases) (no stable release yet → URL pinned to a pre-release tag)
- `delivery_module.lgx` — from the [logos-modules releases](https://github.com/logos-co/logos-modules/releases) (`latest`), which bundle every Logos module

`docs/run-node.md` now splits "Without Docker" into **prebuilt binaries** (Linux only — `logoscore` is published only for Linux) and **build with Nix** (any platform). All three methods default to the `logos.test` fleet; the binary path writes the config inline so no repo clone is needed.

Verified all three download URLs return 200 and inspected the `lgpm` tarball layout. I could not execute the full Linux flow end-to-end from here, so the `load-module`/`createNode`/`start` sequence mirrors the Nix path and the project's "Running Prebuilt logoscore" guidance (capability_module is auto-bound by the daemon).

🤖 Generated with [Claude Code](https://claude.com/claude-code)