### PR TITLE
feat: expose node metrics via collectOpenMetricsText() for openmetrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ The delivery module provides the following API methods (all synchronous, all ret
 - `getAvailableNodeInfoIDs()` - List queryable node info identifiers
 - `getNodeInfo(nodeInfoId: QString)` - Retrieve node info by identifier
 - `getAvailableConfigs()` - Retrieve available configuration parameter descriptions
+- `collectOpenMetricsText()` - Node metrics as OpenMetrics/Prometheus text for the `openmetrics` module (see [Metrics](#metrics))
 
 ### Node Configuration (`createNode`)
 
@@ -196,6 +197,29 @@ carries a `QVariantList data` with positional values:
 - **`connectionStateChanged`** – node connectivity change
   - `data[0]` (`QString`): connection status
   - `data[1]` (`QString`): local timestamp (ISO-8601)
+
+### Metrics
+
+The node already aggregates Prometheus metrics internally (the same set exposed
+on `metricsServerPort`, rendered behind the `"Metrics"` node-info attribute).
+`collectOpenMetricsText()` hands that exposition text back **verbatim** so the
+[`openmetrics`](https://github.com/logos-co/openmetrics-module) module can scrape
+this module without standing up a separate HTTP server — no in-module parsing or
+reshaping. The openmetrics scraper parses the text, injects a
+`module="delivery_module"` label on every series, and merges it with other
+modules.
+
+Point the `openmetrics` module at this one by name, selecting the text-source
+convention with `"format": "text"`:
+
+```bash
+logoscore --config-dir /tmp/om call openmetrics start \
+  '{"port":9090,"modules":[{"name":"delivery_module","format":"text"}]}'
+curl http://localhost:9090/metrics   # every series carries module="delivery_module"
+```
+
+Before a node is created (or if the read fails) `collectOpenMetricsText()`
+returns an empty document so a scrape never errors out on this module.
 
 ## Architecture
 

--- a/src/delivery_module_plugin.cpp
+++ b/src/delivery_module_plugin.cpp
@@ -468,3 +468,27 @@ StdLogosResult DeliveryModuleImpl::getAvailableConfigs() {
 
     return outcome;
 }
+
+std::string DeliveryModuleImpl::collectOpenMetricsText()
+{
+    if (!deliveryCtx) {
+        // No node yet — empty document; the openmetrics scraper renders nothing
+        // for this module rather than treating the scrape as a hard error.
+        return "";
+    }
+
+    auto outcome = callApiRetValue(
+        "get_node_info",
+        CALLBACK_TIMEOUT,
+        bindApiCall(logosdelivery_get_node_info, deliveryCtx, "Metrics"));
+
+    if (!outcome.success || !outcome.value.is_string()) {
+        fprintf(stderr, "DeliveryModuleImpl: collectOpenMetricsText failed to read Metrics node info: %s\n",
+                outcome.error.c_str());
+        return "";
+    }
+
+    // Hand the exposition text back verbatim; the openmetrics module parses it,
+    // injects the module="delivery_module" label, and merges it with others.
+    return outcome.value.get<std::string>();
+}

--- a/src/delivery_module_plugin.h
+++ b/src/delivery_module_plugin.h
@@ -165,6 +165,26 @@ public:
      */
     StdLogosResult getAvailableConfigs();
 
+    /**
+     * @brief Returns the node's metrics as an OpenMetrics/Prometheus text
+     *        document, so the `openmetrics` module can scrape this module.
+     *
+     * liblogosdelivery already aggregates Prometheus metrics in its global
+     * registry and renders them as exposition text behind the `"Metrics"`
+     * node-info attribute. This method just hands that text back verbatim — no
+     * reshaping — which satisfies the openmetrics `metrics_source` interface's
+     * `collectOpenMetricsText()` convention. The openmetrics scraper parses the
+     * text, injects a `module="delivery_module"` label on every series, and
+     * merges it with other modules. Select this method per-module in the
+     * openmetrics `start` config with `{"name":"delivery_module","format":"text"}`.
+     *
+     * Returns an empty string before a node has been created, or when the
+     * underlying read fails, so a scrape never errors out on this module.
+     *
+     * @return OpenMetrics/Prometheus exposition text (possibly empty).
+     */
+    std::string collectOpenMetricsText();
+
     std::string name() const { return "delivery_module"; }
 
     std::string version() const;

--- a/tests/test_delivery_integration.cpp
+++ b/tests/test_delivery_integration.cpp
@@ -137,6 +137,24 @@ LOGOS_TEST(integration_getNodeInfo_returns_value_for_each_id) {
 }
 
 // ---------------------------------------------------------------------------
+// Tests - metrics (openmetrics text source)
+// ---------------------------------------------------------------------------
+
+LOGOS_TEST(integration_collectOpenMetricsText_returns_real_exposition_text) {
+    ensureStarted();
+
+    std::string text = g_impl->collectOpenMetricsText();
+
+    // A started node has eagerly-registered metric families in the global
+    // registry, so the rendered document must be non-empty and look like
+    // Prometheus/OpenMetrics exposition text — exactly what the openmetrics
+    // module's collectOpenMetricsText() text source consumes and re-renders.
+    LOGOS_ASSERT_FALSE(text.empty());
+    LOGOS_ASSERT(text.find("# HELP") != std::string::npos);
+    LOGOS_ASSERT(text.find("# TYPE") != std::string::npos);
+}
+
+// ---------------------------------------------------------------------------
 // Tests - pub/sub (as in simple.cpp)
 // ---------------------------------------------------------------------------
 

--- a/tests/test_delivery_module.cpp
+++ b/tests/test_delivery_module.cpp
@@ -252,6 +252,34 @@ LOGOS_TEST(getAvailableConfigs_returns_empty_on_ffi_failure) {
     LOGOS_ASSERT_FALSE(result.success);
 }
 
+// collectOpenMetricsText
+
+LOGOS_TEST(collectOpenMetricsText_returns_empty_without_createNode) {
+    auto t = LogosTestContext("delivery_module");
+    DeliveryModuleImpl impl;
+
+    LOGOS_ASSERT_EQ(impl.collectOpenMetricsText(), std::string(""));
+    // No context -> we must not even attempt the FFI read.
+    LOGOS_ASSERT_FALSE(t.cFunctionCalled("logosdelivery_get_node_info"));
+}
+
+LOGOS_TEST(collectOpenMetricsText_returns_metrics_text_verbatim) {
+    auto t = LogosTestContext("delivery_module");
+    auto* impl = createInitializedImpl(t);
+
+    const char* promText =
+        "# HELP waku_node_messages_total number of messages\n"
+        "# TYPE waku_node_messages_total counter\n"
+        "waku_node_messages_total{shard=\"0\"} 42\n";
+    t.mockCFunction("logosdelivery_get_node_info").returns(promText);
+
+    // The module is a pure passthrough: the openmetrics scraper does the parsing.
+    LOGOS_ASSERT_EQ(impl->collectOpenMetricsText(), std::string(promText));
+    LOGOS_ASSERT(t.cFunctionCalled("logosdelivery_get_node_info"));
+
+    delete impl;
+}
+
 // module name
 
 LOGOS_TEST(name_returns_delivery_module) {


### PR DESCRIPTION
## What & why

Makes the delivery module scrapeable by the [`openmetrics`](https://github.com/logos-co/openmetrics-module) module using its new **text-source** convention ([openmetrics-module#5](https://github.com/logos-co/openmetrics-module/pull/5), merged), which lets a module hand back already-rendered OpenMetrics/Prometheus text instead of a structured `LogosMap`.

The node **already** aggregates Prometheus metrics in its global registry (the same set served on `metricsServerPort`) and renders them as exposition text behind the `"Metrics"` node-info attribute (`waku_state_info.nim` → `defaultRegistry.toText()`). This PR just exposes that text — verbatim.

## How

- Add `std::string collectOpenMetricsText()` to `DeliveryModuleImpl`. It reads the existing `"Metrics"` node-info attribute over the current FFI (`logosdelivery_get_node_info`) and returns the exposition text **as-is** — no parsing, no reshaping. The module is a pure passthrough; the openmetrics scraper parses the text, injects the `module="delivery_module"` label, and merges it with other sources.
- Returns an empty document before a node exists, or on a read failure, so a scrape never errors out on this module.

Select the text source per-module in the openmetrics `start` config:

```bash
logoscore --config-dir /tmp/om call openmetrics start \
  '{"port":9090,"modules":[{"name":"delivery_module","format":"text"}]}'
curl http://localhost:9090/metrics
```

## Notes

Supersedes #50, which implemented the older structured `collectMetrics()` convention and parsed the exposition text inside the module. With openmetrics-module#5 that parsing now lives once in the scraper, so the module just forwards its native text — simpler and lossless (histograms/summaries round-trip).

## Tests

2 new unit tests (verbatim passthrough; empty without context). Full suite green via `nix build .#unit-tests`: 25 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)