### PR TITLE
chore: release v0.1.3

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
     "name": "delivery_module",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "description": "Logos Delivery Module - High-level message-delivery API",
     "author": "Logos Core Team",
     "type": "core",


### PR DESCRIPTION
Bump `metadata.json` version to `0.1.3` ahead of the v0.1.3 release (patch release targeting Logos Testnet 1).

Release notes are staged as a draft GitHub release for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)