### PR TITLE
ci: switch Nix binary cache from Cachix to Attic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,11 +27,13 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
 
-      - name: Setup Cachix
-        uses: cachix/cachix-action@v15
+      - name: Setup Attic cache
+        uses: ryanccn/attic-action@v0
         with:
-          name: logos-co
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          endpoint: ${{ vars.ATTIC_ENDPOINT }}
+          cache: public
+          token: ${{ secrets.ATTIC_TOKEN_PUBLIC }}
+          skip-push: ${{ github.event_name == 'pull_request' }}
 
       - name: Build module
         run: nix build -L

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Attic cache
         uses: ryanccn/attic-action@v0
         with:
-          endpoint: ${{ vars.ATTIC_ENDPOINT }}
+          endpoint: ${{ secrets.ATTIC_ENDPOINT }}
           cache: public
           token: ${{ secrets.ATTIC_TOKEN_PUBLIC }}
           skip-push: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/doctests.yml
+++ b/.github/workflows/doctests.yml
@@ -54,11 +54,13 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
 
-      - name: Setup Cachix
-        uses: cachix/cachix-action@v15
+      - name: Setup Attic cache
+        uses: ryanccn/attic-action@v0
         with:
-          name: logos-co
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          endpoint: ${{ vars.ATTIC_ENDPOINT }}
+          cache: public
+          token: ${{ secrets.ATTIC_TOKEN_PUBLIC }}
+          skip-push: ${{ github.event_name == 'pull_request' }}
 
       - name: Verify module builds from this commit
         run: nix build .#lgx -L

--- a/.github/workflows/doctests.yml
+++ b/.github/workflows/doctests.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Setup Attic cache
         uses: ryanccn/attic-action@v0
         with:
-          endpoint: ${{ vars.ATTIC_ENDPOINT }}
+          endpoint: ${{ secrets.ATTIC_ENDPOINT }}
           cache: public
           token: ${{ secrets.ATTIC_TOKEN_PUBLIC }}
           skip-push: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
Migrates CI off the (soon-retired) free Cachix plan to the self-hosted Logos Attic cache at \`cache.nix.logos.co\`, per [infra-ci #263](https://github.com/status-im/infra-ci/issues/263).

- Replaces `cachix/cachix-action` with `ryanccn/attic-action` in both `ci.yml` and `doctests.yml`.
- Pushes to the \`public\` cache using the `ATTIC_TOKEN_PUBLIC` org secret + `ATTIC_ENDPOINT` org variable.
- `skip-push` on pull_request, so only `master` builds populate the cache; PRs are read-only.

This is the **pilot** repo for the Attic rollout; `logos-chat-module` (which depends on this repo) is the cross-repo verification step that follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)