### PR TITLE
test: verify Attic public cache hits (no-op, do not merge)

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,3 +252,5 @@ cmake -B build -S . -GNinja
 # Build
 ninja -C build
 ```
+
+<!-- attic cache hit-test PR (no-op, will be closed) -->


### PR DESCRIPTION
Throwaway PR to confirm a PR build substitutes liblogosdelivery/librln from the public Attic cache populated by the #61 master build. Will be closed, not merged.