### PR TITLE
flake: add Logos Attic public cache as substituter

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,13 @@
 {
   description = "Logos Delivery Module";
 
+  # Pull pre-built artifacts (liblogosdelivery, librln, …) from the self-hosted
+  # Logos Attic cache. Read-only and public; see infra-ci#263.
+  nixConfig = {
+    extra-substituters = [ "https://cache.nix.logos.co/public" ];
+    extra-trusted-public-keys = [ "public:Z1wyVBEx8PHbXujYB52Mysv9Rd8rWIhyQ3bQyef9yy4=" ];
+  };
+
   inputs = {
     logos-module-builder.url = "github:logos-co/logos-module-builder";
     nix-bundle-lgx.url = "github:logos-co/nix-bundle-lgx";


### PR DESCRIPTION
Adds the self-hosted Logos Attic **public** cache to `flake.nix` `nixConfig` so local/dev shells and downstream consumers pull prebuilt `liblogosdelivery` / `librln` / nim deps instead of rebuilding. Anonymous, read-only; complements the CI push step from #61. Part of infra-ci #263.

Verified locally: flake evaluates with the new `nixConfig`, and `nix path-info --store https://cache.nix.logos.co/public <liblogosdelivery>` resolves — nix reads the artifacts from the cache. 

```
copying path '/nix/store/awzjh9akddlskapidvj8acdyrxcvnnri-source' from 'https://cache.nix.logos.co/public'...
copying path '/nix/store/wki6r535p9pfmcf80dijhhdjlg5cmy0z-db_connector-29450a2' from 'https://cache.nix.logos.co/public'...
copying path '/nix/store/94jzs1m8xiyvc3r0kqnm8snmpgn6r1fi-dnsclient.nim-2321423' from 'https://cache.nix.logos.co/public'...
copying path '/nix/store/60x62wqvann6xs4pkhr5aajsy2bjx9hx-logos-cpp-sdk-headers-0.1.0' from 'https://cache.nix.logos.co/public'...
copying path '/nix/store/9zmlk3mdqkr1inwaj65iw4bv5g1bdaln-nim-bearssl-22c6a76' from 'https://cache.nix.logos.co/public'...
copying path '/nix/store/jp7jnxkj262xil61b9wrf5v4lc503g71-nim-brokers-2093ca4' from 'https://cache.nix.logos.co/public'...
copying path '/nix/store/23kjlzj7c5qdwq0ykdn3ays8sccm5x0l-nim-chronicles-27ec507' from 'https://cache.nix.logos.co/public'...
copying path '/nix/store/3fjwzlm62higyjz0j16a8gq2pi8nj43b-nim-chronos-45f43a9' from 'https://cache.nix.logos.co/public'...
copying path '/nix/store/sfy65sp5fmixpxasx58r0613dy79imn7-nim-confutils-36f3115' from 'https://cache.nix.logos.co/public'...
copying path '/nix/store/ga9d7x1kpmfygrzgzhjh363qab5jmzwh-nim-dnsdisc-38f2e0f' from 'https://cache.nix.logos.co/public'...
copying path '/nix/store/qmnmd4px6xa7nfz7ynk7bj6ci46z1g5h-nim-eth-d9135e6' from 'https://cache.nix.logos.co/public'...
copying path '/nix/store/sqkpxi90gqihlv3qhly6z8icv7mkzqjh-nim-faststreams-ce27581' from 'https://cache.nix.logos.co/public'...
copying path '/nix/store/scmg2mhhi94zj7v5x7al6fb6ykqssspz-nim-ffi-06111de' from 'https://cache.nix.logos.co/public'...
copying path '/nix/store/b3pcma66jfyby300q4hm9jymgaks1dph-nim-http-utils-f142cb2' from 'https://cache.nix.logos.co/public'...
copying path '/nix/store/w9r3kv2iaqrgqcnvx06ikqvigfzv9nwl-nim-json-rpc-43bbf49' from 'https://cache.nix.logos.co/public'...
copying path '/nix/store/1a1sl0390iv6d95a27lp54afx2vxjijx-nim-json-serialization-c343b0e' from 'https://cache.nix.logos.co/public'...
copying path '/nix/store/4cfaaak3jj1wiljj2v7nxm1x0jz6sich-nim-libp2p-ff8d518' from 'https://cache.nix.logos.co/public'...
copying path '/nix/store/mcpqy97v4pzv4kniry4fnnhzm63qsglg-nim-lsquic-4fb03ee' from 'https://cache.nix.logos.co/public'...
copying path '/nix/store/z9p8a1hvlif7zxj8vbrh60ipw79f35sr-nim-metrics-a1296ca' from 'https://cache.nix.logos.co/public'...
copying path '/nix/store/4ijlyzxs2vcf4hcxid8k9bjz8wjv54hq-nim-minilru-6dd93fe' from 'https://cache.nix.logos.co/public'...
copying path '/nix/store/hpp4p6gjqiin40v8zyxx2mbnramxqins-nim-presto-d66043d' from 'https://cache.nix.logos.co/public'...
copying path '/nix/store/ali6k1g8g4xsng6pcn36hnavwi8g7f3x-nim-regex-4593305' from 'https://cache.nix.logos.co/public'...
copying path '/nix/store/k3zvbrwkk05cslp94r35jf9vs9692b5c-nim-results-df8113d' from 'https://cache.nix.logos.co/public'...
copying path '/nix/store/gxm6rx785lfk8psbi4f5vpm7kyxyv3xx-nim-secp256k1-d8f1288' from 'https://cache.nix.logos.co/public'...
copying path '/nix/store/s1lm4ndib8c0srz67h217bf2mcyf8bh0-nim-serialization-b0f2fa3' from 'https://cache.nix.logos.co/public'...
copying path '/nix/store/yqx4niv7f62la5pzdrgh25nsa5j6bzl9-nim-stew-4382b18' from 'https://cache.nix.logos.co/public'...
copying path '/nix/store/48wxrlby0iv043rz22j1v72jcl2q40sy-nim-stint-470b789' from 'https://cache.nix.logos.co/public'...
copying path '/nix/store/b7ix4lw4z8803d4h8z8c4zz8blcb9n6g-nim-taskpools-9e8ccc7' from 'https://cache.nix.logos.co/public'...
copying path '/nix/store/ibl1wfzwfb7acdwaa8kri8vbj4xjq2xy-nim-toml-serialization-b5b387e' from 'https://cache.nix.logos.co/public'...
copying path '/nix/store/q6aigvm8a4iqs991hlnjbizmx0xdlx1z-nim-unicodedb-66f2458' from 'https://cache.nix.logos.co/public'...
copying path '/nix/store/d40zlv8vn80pv2l35bxbr29kkmbrrnwv-nim-web3-cdfe560' from 'https://cache.nix.logos.co/public'...
copying path '/nix/store/0v6nz0jbr0b9p6zf9zfs40mg6iq7dws8-nim-websock-c105d98' from 'https://cache.nix.logos.co/public'...
copying path '/nix/store/kd5mf7w3v8qk6ybrvyiqpmbd02dksxyw-nim-zlib-e680f26' from 'https://cache.nix.logos.co/public'...
copying path '/nix/store/a1x9zzciwi9dh82lqjlmlllfdvx80wfn-nimcrypto-721fb99' from 'https://cache.nix.logos.co/public'...
copying path '/nix/store/k1wnybd7kjn747vr0saj4p3ydyi06hm7-zerokit-2.0.2' from 'https://cache.nix.logos.co/public'...
copying path '/nix/store/ajinadnbhava09sc7sakncin6c4686v7-logos-module-0.1.0' from 'https://cache.nix.logos.co/public'...
copying path '/nix/store/gfdgh42z3lyk8pix5x2kp1gjv3p26qmr-logos-cpp-sdk-lib-0.1.0' from 'https://cache.nix.logos.co/public'...
copying path '/nix/store/ymj6pq4z62x75zl167vnqbp6jsiz28ww-logos-cpp-sdk-generator-0.1.0' from 'https://cache.nix.logos.co/public'...
```



🤖 Generated with [Claude Code](https://claude.com/claude-code)