### PR TITLE
flake: cap the delivery node's log level at build time

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,13 @@ values that differ from defaults need to be supplied.
 | `logFormat`          | string           | `"TEXT"`   | `"TEXT"` or `"JSON"`                     |
 | `maxMessageSize`     | string           | `"150KiB"` | Maximum message payload size             |
 
+`logLevel` reaches the node but does not change how much it logs. The bundled
+liblogosdelivery resolves each log statement's level when it is compiled, so the
+ceiling is a build-time property; this module pins it to `WARN` in `flake.nix` to
+keep the node's peer-discovery and subscription-upkeep chatter out of an
+embedding host's console. Lower it there and rebuild the library to get those
+diagnostics back.
+
 #### Presets
 
 Using a `preset` populates cluster ID, entry nodes, sharding, RLN, and other

--- a/flake.nix
+++ b/flake.nix
@@ -15,13 +15,31 @@
   };
 
   outputs = inputs@{ logos-module-builder, ... }:
+    let
+      # The node's own logger drowns an embedding host: peer discovery,
+      # subscription upkeep and mesh heartbeats all log at INFO or DEBUG,
+      # several lines a second, whatever `logLevel` the caller passes to
+      # createNode. That key cannot silence them, because chronicles resolves
+      # each statement's level at compile time unless the library is built with
+      # `chronicles_runtime_filtering`, which it is not, leaving nothing to read
+      # the level the node stores at startup. Cap it at build time instead.
+      # Lowering this restores the node's diagnostics and costs a source build
+      # of the library, which the binary cache has only for this value.
+      quietedDelivery.packages = builtins.mapAttrs
+        (_system: systemPackages: {
+          liblogosdelivery = systemPackages.liblogosdelivery.override {
+            chroniclesLogLevel = "WARN";
+          };
+        })
+        inputs.logos-delivery.packages;
+    in
     logos-module-builder.lib.mkLogosModule {
       src = ./.;
       configFile = ./metadata.json;
       flakeInputs = inputs;
       externalLibInputs = {
         logosdelivery = {
-          input = inputs.logos-delivery;
+          input = quietedDelivery;
           packages.default = "liblogosdelivery";
         };
         # Bundle librln.dylib alongside liblogosdelivery.dylib so the transitive


### PR DESCRIPTION
Fixes logos-co/logos-chat-ui#37.

The console flood reported there is the embedded liblogosdelivery node's own chronicles output on stdout, not this plugin's diagnostics: peer discovery (`received random records from kademlia` every few seconds), subscription upkeep (`maintaining subscriptions`, `cleanUp`), autonat probes and `Missed multiple heartbeats`, at INFO and DEBUG.

The `logLevel` key callers pass to `createNode` cannot turn them off. It is plumbed all the way through to chronicles' `topics_registry.setLogLevel`, but chronicles resolves each statement's level at compile time unless the library is built with `chronicles_runtime_filtering`, which no build path in logos-delivery enables. So the level a node stores at startup has nothing reading it, and `"logLevel": "ERROR"` (which logos-chat-module already sends) does nothing.

Since the ceiling is a build-time property, set it at build time: override `chroniclesLogLevel` on the `liblogosdelivery` package. `nix/default.nix` upstream already exposes that argument and consumes the package through `callPackage`, so `.override` is available; libchat pins it to `FATAL` the same way. WARN is the level that drops the traffic above while keeping anything that reports a problem.

Two consequences worth knowing:

- Lowering the level for troubleshooting now means editing `flake.nix` and rebuilding the library from source, since the binary cache only carries the value committed here. Expect this PR's first CI run to build liblogosdelivery rather than substitute it, for the same reason.
- The `logLevel` config key stays inert for the node. The README now says so rather than implying it works. Making it live would need `chronicles_runtime_filtering` enabled upstream in logos-delivery.

Separate from #65, which gates this plugin's own stderr diagnostics. The two are complementary and neither depends on the other.