### PR TITLE
ci: use rotated Attic secrets and per-cache tokens

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,14 +10,12 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  ATTIC_CACHE: ${{ github.ref == 'refs/heads/master' && 'public' || 'ci' }}
-
 jobs:
   build-and-test:
-    # ATTIC_TOKEN_PUBLIC only exists in the public-cache environment; master
-    # builds run there so they can push to the public cache. Everything else
-    # uses the repo-wide ATTIC_TOKEN_CI and the ci cache.
+    # master builds push what they build to the public Attic cache;
+    # ATTIC_TOKEN_PUBLIC only exists in the public-cache environment.
+    # Pulling needs no setup — the cache is a public substituter declared
+    # in flake.nix (accept-flake-config below turns it on in CI).
     environment: ${{ github.ref == 'refs/heads/master' && 'public-cache' || '' }}
     strategy:
       fail-fast: false
@@ -35,16 +33,16 @@ jobs:
         uses: DeterminateSystems/nix-installer-action@main
         with:
           extra-conf: |
-            extra-substituters = https://cache.nix.logos.co/public
-            extra-trusted-public-keys = public:l4HrXgL4nw246+LBh2SOJyhz64BoGegOYLheT/iIAPU=
+            accept-flake-config = true
             fallback = true
 
-      - name: Setup Attic cache
+      - name: Push builds to Attic public cache
+        if: github.ref == 'refs/heads/master'
         uses: ryanccn/attic-action@v0.4.1
         with:
           endpoint: ${{ secrets.ATTIC_ENDPOINT }}
-          cache: ${{ env.ATTIC_CACHE }}
-          token: ${{ github.ref == 'refs/heads/master' && secrets.ATTIC_TOKEN_PUBLIC || secrets.ATTIC_TOKEN_CI }}
+          cache: public
+          token: ${{ secrets.ATTIC_TOKEN_PUBLIC }}
 
       - name: Build module
         run: nix build -L

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,12 +10,11 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  ATTIC_CACHE: ${{ github.ref == 'refs/heads/master' && 'public' || 'ci' }}
+
 jobs:
   build-and-test:
-    # master builds push what they build to the public Attic cache;
-    # ATTIC_TOKEN_PUBLIC only exists in the public-cache environment.
-    # Pulling needs no setup — the cache is a public substituter declared
-    # in flake.nix (accept-flake-config below turns it on in CI).
     environment: ${{ github.ref == 'refs/heads/master' && 'public-cache' || '' }}
     strategy:
       fail-fast: false
@@ -29,20 +28,29 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # Both caches are public to read, so the substituters go in the Nix
+      # install where they need no credentials, keeping fork PRs and any other
+      # run without secrets on the fast path.
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
         with:
           extra-conf: |
-            accept-flake-config = true
+            extra-substituters = https://cache.nix.logos.co/public https://cache.nix.logos.co/ci
+            extra-trusted-public-keys = public:l4HrXgL4nw246+LBh2SOJyhz64BoGegOYLheT/iIAPU= ci:aVJqjS4NWX5WfqHO0AEhIScjGu/JyK5FoydPrnEbMvc=
             fallback = true
 
-      - name: Push builds to Attic public cache
-        if: github.ref == 'refs/heads/master'
+      # Publishing only; reading is covered by the substituters above.
+      # ATTIC_TOKEN_PUBLIC lives in the public-cache environment, so only the
+      # master jobs that opt into it reach the public cache; every other ref
+      # pushes to ci with the repo-wide token. Fork PRs get no secrets, and an
+      # empty endpoint fails `attic use`.
+      - name: Setup Attic cache
+        if: github.event.pull_request.head.repo.fork != true
         uses: ryanccn/attic-action@v0.4.1
         with:
           endpoint: ${{ secrets.ATTIC_ENDPOINT }}
-          cache: public
-          token: ${{ secrets.ATTIC_TOKEN_PUBLIC }}
+          cache: ${{ env.ATTIC_CACHE }}
+          token: ${{ github.ref == 'refs/heads/master' && secrets.ATTIC_TOKEN_PUBLIC || secrets.ATTIC_TOKEN_CI }}
 
       - name: Build module
         run: nix build -L

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,15 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  ATTIC_CACHE: ${{ github.ref == 'refs/heads/master' && 'public' || 'ci' }}
+
 jobs:
   build-and-test:
+    # ATTIC_TOKEN_PUBLIC only exists in the public-cache environment; master
+    # builds run there so they can push to the public cache. Everything else
+    # uses the repo-wide ATTIC_TOKEN_CI and the ci cache.
+    environment: ${{ github.ref == 'refs/heads/master' && 'public-cache' || '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -26,14 +33,18 @@ jobs:
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
+        with:
+          extra-conf: |
+            extra-substituters = https://cache.nix.logos.co/public
+            extra-trusted-public-keys = public:l4HrXgL4nw246+LBh2SOJyhz64BoGegOYLheT/iIAPU=
+            fallback = true
 
       - name: Setup Attic cache
-        uses: ryanccn/attic-action@v0
+        uses: ryanccn/attic-action@v0.4.1
         with:
           endpoint: ${{ secrets.ATTIC_ENDPOINT }}
-          cache: public
-          token: ${{ secrets.ATTIC_TOKEN_PUBLIC }}
-          skip-push: ${{ github.event_name == 'pull_request' }}
+          cache: ${{ env.ATTIC_CACHE }}
+          token: ${{ github.ref == 'refs/heads/master' && secrets.ATTIC_TOKEN_PUBLIC || secrets.ATTIC_TOKEN_CI }}
 
       - name: Build module
         run: nix build -L

--- a/.github/workflows/doctests.yml
+++ b/.github/workflows/doctests.yml
@@ -36,9 +36,16 @@ concurrency:
   group: doctests-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  ATTIC_CACHE: ${{ github.ref == 'refs/heads/master' && 'public' || 'ci' }}
+
 jobs:
   doctests:
     name: delivery-module doc-tests (${{ matrix.os }})
+    # ATTIC_TOKEN_PUBLIC only exists in the public-cache environment; master
+    # builds run there so they can push to the public cache. Everything else
+    # uses the repo-wide ATTIC_TOKEN_CI and the ci cache.
+    environment: ${{ github.ref == 'refs/heads/master' && 'public-cache' || '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -53,14 +60,18 @@ jobs:
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
+        with:
+          extra-conf: |
+            extra-substituters = https://cache.nix.logos.co/public
+            extra-trusted-public-keys = public:l4HrXgL4nw246+LBh2SOJyhz64BoGegOYLheT/iIAPU=
+            fallback = true
 
       - name: Setup Attic cache
-        uses: ryanccn/attic-action@v0
+        uses: ryanccn/attic-action@v0.4.1
         with:
           endpoint: ${{ secrets.ATTIC_ENDPOINT }}
-          cache: public
-          token: ${{ secrets.ATTIC_TOKEN_PUBLIC }}
-          skip-push: ${{ github.event_name == 'pull_request' }}
+          cache: ${{ env.ATTIC_CACHE }}
+          token: ${{ github.ref == 'refs/heads/master' && secrets.ATTIC_TOKEN_PUBLIC || secrets.ATTIC_TOKEN_CI }}
 
       - name: Verify module builds from this commit
         run: nix build .#lgx -L

--- a/.github/workflows/doctests.yml
+++ b/.github/workflows/doctests.yml
@@ -36,13 +36,12 @@ concurrency:
   group: doctests-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  ATTIC_CACHE: ${{ github.ref == 'refs/heads/master' && 'public' || 'ci' }}
+
 jobs:
   doctests:
     name: delivery-module doc-tests (${{ matrix.os }})
-    # master builds push what they build to the public Attic cache;
-    # ATTIC_TOKEN_PUBLIC only exists in the public-cache environment.
-    # Pulling needs no setup — the cache is a public substituter declared
-    # in flake.nix (accept-flake-config below turns it on in CI).
     environment: ${{ github.ref == 'refs/heads/master' && 'public-cache' || '' }}
     strategy:
       fail-fast: false
@@ -56,20 +55,29 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # Both caches are public to read, so the substituters go in the Nix
+      # install where they need no credentials, keeping fork PRs and any other
+      # run without secrets on the fast path.
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
         with:
           extra-conf: |
-            accept-flake-config = true
+            extra-substituters = https://cache.nix.logos.co/public https://cache.nix.logos.co/ci
+            extra-trusted-public-keys = public:l4HrXgL4nw246+LBh2SOJyhz64BoGegOYLheT/iIAPU= ci:aVJqjS4NWX5WfqHO0AEhIScjGu/JyK5FoydPrnEbMvc=
             fallback = true
 
-      - name: Push builds to Attic public cache
-        if: github.ref == 'refs/heads/master'
+      # Publishing only; reading is covered by the substituters above.
+      # ATTIC_TOKEN_PUBLIC lives in the public-cache environment, so only the
+      # master jobs that opt into it reach the public cache; every other ref
+      # pushes to ci with the repo-wide token. Fork PRs get no secrets, and an
+      # empty endpoint fails `attic use`.
+      - name: Setup Attic cache
+        if: github.event.pull_request.head.repo.fork != true
         uses: ryanccn/attic-action@v0.4.1
         with:
           endpoint: ${{ secrets.ATTIC_ENDPOINT }}
-          cache: public
-          token: ${{ secrets.ATTIC_TOKEN_PUBLIC }}
+          cache: ${{ env.ATTIC_CACHE }}
+          token: ${{ github.ref == 'refs/heads/master' && secrets.ATTIC_TOKEN_PUBLIC || secrets.ATTIC_TOKEN_CI }}
 
       - name: Verify module builds from this commit
         run: nix build .#lgx -L

--- a/.github/workflows/doctests.yml
+++ b/.github/workflows/doctests.yml
@@ -36,15 +36,13 @@ concurrency:
   group: doctests-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  ATTIC_CACHE: ${{ github.ref == 'refs/heads/master' && 'public' || 'ci' }}
-
 jobs:
   doctests:
     name: delivery-module doc-tests (${{ matrix.os }})
-    # ATTIC_TOKEN_PUBLIC only exists in the public-cache environment; master
-    # builds run there so they can push to the public cache. Everything else
-    # uses the repo-wide ATTIC_TOKEN_CI and the ci cache.
+    # master builds push what they build to the public Attic cache;
+    # ATTIC_TOKEN_PUBLIC only exists in the public-cache environment.
+    # Pulling needs no setup — the cache is a public substituter declared
+    # in flake.nix (accept-flake-config below turns it on in CI).
     environment: ${{ github.ref == 'refs/heads/master' && 'public-cache' || '' }}
     strategy:
       fail-fast: false
@@ -62,16 +60,16 @@ jobs:
         uses: DeterminateSystems/nix-installer-action@main
         with:
           extra-conf: |
-            extra-substituters = https://cache.nix.logos.co/public
-            extra-trusted-public-keys = public:l4HrXgL4nw246+LBh2SOJyhz64BoGegOYLheT/iIAPU=
+            accept-flake-config = true
             fallback = true
 
-      - name: Setup Attic cache
+      - name: Push builds to Attic public cache
+        if: github.ref == 'refs/heads/master'
         uses: ryanccn/attic-action@v0.4.1
         with:
           endpoint: ${{ secrets.ATTIC_ENDPOINT }}
-          cache: ${{ env.ATTIC_CACHE }}
-          token: ${{ github.ref == 'refs/heads/master' && secrets.ATTIC_TOKEN_PUBLIC || secrets.ATTIC_TOKEN_CI }}
+          cache: public
+          token: ${{ secrets.ATTIC_TOKEN_PUBLIC }}
 
       - name: Verify module builds from this commit
         run: nix build .#lgx -L

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
   # Logos Attic cache. Read-only and public; see infra-ci#263.
   nixConfig = {
     extra-substituters = [ "https://cache.nix.logos.co/public" ];
-    extra-trusted-public-keys = [ "public:Z1wyVBEx8PHbXujYB52Mysv9Rd8rWIhyQ3bQyef9yy4=" ];
+    extra-trusted-public-keys = [ "public:l4HrXgL4nw246+LBh2SOJyhz64BoGegOYLheT/iIAPU=" ];
   };
 
   inputs = {


### PR DESCRIPTION
infra-ci [#263](https://github.com/status-im/infra-ci/issues/263) is done and the Attic secrets were restructured and rotated since #61/#63 merged: `ATTIC_TOKEN_CI` + `ATTIC_ENDPOINT` are repo-wide, `ATTIC_TOKEN_PUBLIC` only exists in the `public-cache` environment. This aligns the workflows, mirroring logos-co/logos-chat-module#40:

- Both caches are anonymously readable, so the **substituters live in the Nix install step**, credential-free — fork PRs and runs without secrets still pull.
- `ryanccn/attic-action@v0.4.1` is **publishing only**: non-master refs push what they build to the **`ci` cache** with `ATTIC_TOKEN_CI`; `master` pushes to **`public`** from the `public-cache` environment with `ATTIC_TOKEN_PUBLIC`.
- **`flake.nix`: rotated public-cache signing key.** The old `public:Z1wyVBEx…` no longer matches the server; the live key (from `/_api/v1/cache-config/public`) is `public:l4HrXgL4nw246+LBh2SOJyhz64BoGegOYLheT/iIAPU=`. Without it, local users silently fall back to building from source.

The public cache was recreated during rotation and contains none of this repo's closure; the first `master` build after merging repopulates it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)