### PR TITLE
ci: switch the Nix cache setup to setup-nix-cache-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ concurrency:
 
 jobs:
   build-and-test:
+    environment: ${{ github.ref == 'refs/heads/master' && 'public-cache' || '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -24,16 +25,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@main
-
-      - name: Setup Attic cache
-        uses: ryanccn/attic-action@v0
+      - name: Setup Nix and Logos cache
+        uses: logos-co/setup-nix-cache-action@v1
         with:
-          endpoint: ${{ secrets.ATTIC_ENDPOINT }}
-          cache: public
-          token: ${{ secrets.ATTIC_TOKEN_PUBLIC }}
-          skip-push: ${{ github.event_name == 'pull_request' }}
+          attic-token-ci: ${{ secrets.ATTIC_TOKEN_CI }}
+          attic-token-public: ${{ secrets.ATTIC_TOKEN_PUBLIC }}
 
       - name: Build module
         run: nix build -L

--- a/.github/workflows/doctests.yml
+++ b/.github/workflows/doctests.yml
@@ -39,6 +39,7 @@ concurrency:
 jobs:
   doctests:
     name: delivery-module doc-tests (${{ matrix.os }})
+    environment: ${{ github.ref == 'refs/heads/master' && 'public-cache' || '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -51,16 +52,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@main
-
-      - name: Setup Attic cache
-        uses: ryanccn/attic-action@v0
+      - name: Setup Nix and Logos cache
+        uses: logos-co/setup-nix-cache-action@v1
         with:
-          endpoint: ${{ secrets.ATTIC_ENDPOINT }}
-          cache: public
-          token: ${{ secrets.ATTIC_TOKEN_PUBLIC }}
-          skip-push: ${{ github.event_name == 'pull_request' }}
+          attic-token-ci: ${{ secrets.ATTIC_TOKEN_CI }}
+          attic-token-public: ${{ secrets.ATTIC_TOKEN_PUBLIC }}
 
       - name: Verify module builds from this commit
         run: nix build .#lgx -L

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
   # Logos Attic cache. Read-only and public; see infra-ci#263.
   nixConfig = {
     extra-substituters = [ "https://cache.nix.logos.co/public" ];
-    extra-trusted-public-keys = [ "public:Z1wyVBEx8PHbXujYB52Mysv9Rd8rWIhyQ3bQyef9yy4=" ];
+    extra-trusted-public-keys = [ "public:l4HrXgL4nw246+LBh2SOJyhz64BoGegOYLheT/iIAPU=" ];
   };
 
   inputs = {


### PR DESCRIPTION
Same change as logos-co/logos-chat-module#57: each job's Nix + Attic cache setup becomes the [`setup-nix-cache-action@v1`](https://github.com/logos-co/setup-nix-cache-action) call — pull from both caches on every ref, publish `master` → `public` (via the `public-cache` environment), other refs → `ci`.

Also rotates the public-cache signing key in `flake.nix` (the old key no longer matches the server, so local pulls silently built from source).

Supersedes #67.

🤖 Generated with [Claude Code](https://claude.com/claude-code)