### PR TITLE
ci: use setup-nix-cache-action in e2e-tests instead of cachix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,11 +37,12 @@ jobs:
       - name: Run tests
         run: nix build .#unit-tests -L
 
-      - name: Pre-warm cachix for install-portable
+      - name: Pre-warm cache for install-portable
         if: matrix.os == 'ubuntu-latest'
         run: nix build -L .#install-portable
 
   e2e-tests:
+    environment: ${{ github.ref == 'refs/heads/master' && 'public-cache' || '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 50
     needs: build-and-test
@@ -50,14 +51,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@main
-
-      - name: Setup Cachix
-        uses: cachix/cachix-action@v15
+      - name: Setup Nix and Logos cache
+        uses: logos-co/setup-nix-cache-action@v1
         with:
-          name: logos-co
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          attic-token-ci: ${{ secrets.ATTIC_TOKEN_CI }}
+          attic-token-public: ${{ secrets.ATTIC_TOKEN_PUBLIC }}
 
       - name: Build delivery-module (install-portable layout)
         run: |


### PR DESCRIPTION
The `e2e-tests` job added in #51 predates the Attic migration (#69) and still installed Nix via `DeterminateSystems/nix-installer-action` + pulled through cachix.

Switch it to `logos-co/setup-nix-cache-action@v1` like `build-and-test`:
- both Logos caches (`public` + `ci`) as credential-free substituters, so `nix build .#install-portable` and the logoscore CLI build pull from cache.nix.logos.co
- publishes what the job builds (master → `public`, PRs → `ci`), with the same `public-cache` environment gate on master
- drops the `CACHIX_AUTH_TOKEN` dependency

Also renames the stale "Pre-warm cachix" step in `build-and-test` — it has published to Attic since #69.

🤖 Generated with [Claude Code](https://claude.com/claude-code)