### PR TITLE
fix: store node data under the module's per-instance path

### DIFF
--- a/src/delivery_module_plugin.cpp
+++ b/src/delivery_module_plugin.cpp
@@ -1,6 +1,8 @@
 #include "delivery_module_plugin.h"
+#include <cctype>
 #include <cstdio>
 #include <ctime>
+#include <initializer_list>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -154,13 +156,39 @@ void DeliveryModuleImpl::event_callback(int callerRet, const char* msg, size_t l
     }
 }
 
+// True when cfgObj already carries one of `names`. The upstream JSON conf
+// parser keys fields case-insensitively and matches either the Nim field name
+// or its CLI `name:` pragma, so a caller may legitimately spell a key several
+// ways; matching the same way keeps us from overriding their value.
+static bool containsAnyKey(const nlohmann::json& cfgObj,
+                           std::initializer_list<const char*> names)
+{
+    for (const auto& entry : cfgObj.items()) {
+        std::string key = entry.key();
+        for (auto& c : key) c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+        for (const char* name : names) {
+            if (key == name) return true;
+        }
+    }
+    return false;
+}
+
 // Default every listening port (tcpPort, discv5UdpPort, restPort,
 // metricsServerPort, websocketPort) to 0 so the OS assigns an ephemeral port
 // when the caller did not pin a specific value. Caller-supplied ports are
 // preserved so fleet configs that pin ports keep working. logos-delivery now
 // accepts port 0 (status-im/nim-confutils#146), which makes this work.
 // See logos-delivery-module#18.
-static std::optional<std::string> applyPortDefaults(const std::string& cfg)
+//
+// Also default the node's storage directory to the per-instance path the host
+// provisions for this module. logos-delivery otherwise falls back to "./data"
+// (persistency.nim DefaultStoragePath), which is relative to the process
+// working directory and therefore identical for every instance launched from
+// it — side-by-side instances would share one SQLite file. The path is empty
+// when the module runs outside a host that provisions persistence (unit tests
+// constructing the impl directly), in which case upstream's default stands.
+static std::optional<std::string> applyConfigDefaults(const std::string& cfg,
+                                                      const std::string& persistencePath)
 {
     nlohmann::json cfgObj;
     try {
@@ -187,6 +215,11 @@ static std::optional<std::string> applyPortDefaults(const std::string& cfg)
         }
     }
 
+    if (!persistencePath.empty()
+        && !containsAnyKey(cfgObj, {"localstoragepath", "local-storage-path"})) {
+        cfgObj["localStoragePath"] = persistencePath + "/data";
+    }
+
     return cfgObj.dump();
 }
 
@@ -202,7 +235,7 @@ StdLogosResult DeliveryModuleImpl::createNode(const std::string& cfg)
     // Don't log cfg: it can carry sensitive config.
     fprintf(stderr, "DeliveryModuleImpl::createNode called\n");
 
-    auto cfgWithDefaults = applyPortDefaults(cfg);
+    auto cfgWithDefaults = applyConfigDefaults(cfg, instancePersistencePath());
     if (!cfgWithDefaults) {
         return {false, {}, "Invalid JSON config"};
     }


### PR DESCRIPTION
## Summary

Default the node's storage directory to the per-instance path the host provisions for this module, so side-by-side instances stop sharing one database.

`createNode` never set a storage path, so logos-delivery fell back to `DefaultStoragePath = "./data"` ([`persistency.nim:53`](https://github.com/logos-messaging/logos-delivery/blob/master/logos_delivery/waku/persistency/persistency.nim)) — **relative to the process working directory**. The standalone app does not `chdir` into the session directory; it only calls `logos_core_set_persistence_base_path(<session dir>/module_data)` and hands each module instance its own directory underneath. So two instances launched from the same working directory both opened `./data/sds.db`: one SQLite file, two concurrent writers, and per-channel SDS state keyed identically across the two nodes.

That makes `--user-dir` — the documented way to run instances side by side — not actually isolate delivery state.

`DeliveryModuleImpl` already inherits `LogosModuleContext`, so the correct directory was available all along as `instancePersistencePath()`. `applyPortDefaults` becomes `applyConfigDefaults` and now also fills in `localStoragePath` when the caller left it unset.

## Behaviour

- Caller-supplied storage path always wins. The upstream JSON parser matches a conf field by its Nim name *or* its CLI `name:` pragma, case-insensitively, so both `localStoragePath` and `local-storage-path` (any casing) are recognised as caller-set and left alone.
- Outside a host that provisions persistence — unit tests constructing the impl directly — `instancePersistencePath()` is empty and upstream's `./data` default stands, unchanged.
- Ports behave exactly as before.

## Testing

- `nix build .#unit-tests -L` — 29 passed.

## Note

This lands on the flat config shape that today's pinned logos-delivery accepts. [#68](https://github.com/logos-co/logos-delivery-module/pull/68) bumps logos-delivery to a version whose parser rejects unknown top-level keys once a `messagingOverrides` / `channelsOverrides` / `kernelConf` wrapper is present — the same constraint already applies to the port defaults, and both need routing into the wrapper as part of that bump rather than here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
