### PR TITLE
ci: speed up e2e-tests CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,14 +66,14 @@ jobs:
         run: |
           git clone https://github.com/logos-co/logos-logoscore-py.git /tmp/logoscore-py
           cd /tmp/logoscore-py
-          git checkout 71e003813a8633e9efadaf6ab66a6b0615dcc0f5
+          git checkout a58573eb2c33916c0da2ba08ecb1ceca2fbb7617
           bash tests/docker_smoke/build_smoke_image.sh
           echo "LOGOSCORE_IMAGE=logoscore:smoke-portable" >> $GITHUB_ENV
 
       - name: Build logoscore CLI binary (host PATH)
         # Must match the daemon commit baked into the smoke image above.
         run: |
-          nix build -L --out-link /tmp/logoscore-cli "github:logos-co/logos-logoscore-cli/a9e184557aa1a29cee23837fa4af5c0a50fd1673#cli"
+          nix build -L --out-link /tmp/logoscore-cli "github:logos-co/logos-logoscore-cli/665ac28bc77f45e3c610f40fef975a12609de531#cli"
           echo "/tmp/logoscore-cli/bin" >> $GITHUB_PATH
 
       - uses: actions/setup-python@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,13 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      # type=gha needs ACTIONS_RUNTIME_TOKEN/ACTIONS_CACHE_URL, which
+      # GitHub only injects into actions — this exposes them to run
+      # steps, so buildx invoked from build_smoke_image.sh can reach
+      # the cache API. Without it the gha cache is silently a no-op.
+      - name: Expose Actions runtime for buildx gha cache
+        uses: crazy-max/ghaction-github-runtime@v3
+
       - name: Build delivery-module (install-portable layout)
         run: |
           nix build -L .#install-portable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,12 +56,20 @@ jobs:
           attic-token-ci: ${{ secrets.ATTIC_TOKEN_CI }}
           attic-token-public: ${{ secrets.ATTIC_TOKEN_PUBLIC }}
 
+      # The gha cache backend needs the docker-container driver;
+      # the default docker driver can't export type=gha.
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build delivery-module (install-portable layout)
         run: |
           nix build -L .#install-portable
           echo "LOGOS_MODULES_DIR=$PWD/result/modules" >> $GITHUB_ENV
 
       - name: Checkout logoscore-py and build smoke image
+        env:
+          BUILDX_CACHE_FROM: type=gha
+          BUILDX_CACHE_TO: type=gha,mode=max
         run: |
           git clone https://github.com/logos-co/logos-logoscore-py.git /tmp/logoscore-py
           cd /tmp/logoscore-py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,6 @@ jobs:
     environment: ${{ github.ref == 'refs/heads/master' && 'public-cache' || '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 50
-    needs: build-and-test
     continue-on-error: true
     steps:
       - name: Checkout


### PR DESCRIPTION
Speeds up the `e2e-tests` job and CI wall clock overall.

- **Bump logoscore-py pin** `71e0038` → `a58573e`: picks up logos-co/logos-logoscore-py#12 (Attic substituters in the smoke image's build stage). The logoscore-cli host pin moves `a9e1845` → `665ac28` in lockstep — logoscore-py bumped its flake pin in #10, and the host CLI must match the daemon baked into the image.
- **Run e2e in parallel with build-and-test**: the job builds everything it needs itself (Attic-cached), so `needs: build-and-test` only added the slower macos leg (~4 min) to the wall clock.
- **Buildx GHA layer cache for the smoke image**: `setup-buildx-action` + `BUILDX_CACHE_FROM/TO=type=gha`, which `build_smoke_image.sh` forwards. Since the logoscore-py pin fixes the build input, every run until the next pin bump replays the whole docker build — including the ~5 min inner `nix build` — from cache.
- **Expose the Actions runtime env** (`crazy-max/ghaction-github-runtime`): `type=gha` needs `ACTIONS_RUNTIME_TOKEN`/`ACTIONS_CACHE_URL`, which GitHub injects into actions but not `run:` steps — without this, buildx silently skips the cache. logoscore-py's own CI has the same latent no-op (fix to follow there).

Measured: warm-cache CI wall clock **17m23s → ~6m** (e2e job 6m04s, running parallel to build-and-test). Smoke image step 13m51s → 2m31s warm (7 CACHED layers incl. the inner nix build; remainder is layer download + --load), host CLI build 3m54s → 50s off the Attic ci cache. A logoscore-py pin bump costs one ~15m seeding run (rebuild + cache export), then back to ~6m.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
