### PR TITLE
flake: bundle what librln loads

### DIFF
--- a/.github/workflows/doctests.yml
+++ b/.github/workflows/doctests.yml
@@ -61,9 +61,32 @@ jobs:
       - name: Verify module builds from this commit
         run: nix build .#lgx -L
 
+      # Resolve the commit under test. For pull requests this is the PR's head
+      # commit (not the synthetic merge commit); for pushes it's the pushed
+      # commit.
+      #
+      # Fork PRs are the exception: their head commit lives in the fork, not in
+      # logos-co/logos-delivery-module, so nix could not fetch
+      # `github:logos-co/logos-delivery-module/<sha>`. We blank the SHA for
+      # forks (--release-for repo= → pins that repo to latest), so the doc-test
+      # still runs for fork PRs, just against master.
+      - name: Resolve commit under test
+        id: commit
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ] && \
+             [ "${{ github.event.pull_request.head.repo.fork }}" = "true" ]; then
+            echo "sha=" >> "$GITHUB_OUTPUT"
+            echo "Fork PR detected — doc-test will run against latest master."
+          else
+            echo "sha=${{ github.event.pull_request.head.sha || github.sha }}" >> "$GITHUB_OUTPUT"
+          fi
+
       # The runner is the shared `doctest` CLI, invoked directly via its flake
       # (github:logos-co/logos-doctest). The flake bundles Python + PyYAML
-      # (+ rich), so no pip install step is needed.
+      # (+ rich), so no pip install step is needed. --release-for pins the
+      # {release} placeholder to the commit under test, so the `#lgx` the spec
+      # installs is the one this commit produces.
       - name: Run delivery-module runtime doc-test
         run: |
           # --continue-on-fail so the run walks every step and the published
@@ -73,6 +96,7 @@ jobs:
             doctests/delivery-module-runtime.test.yaml \
             --verbose \
             --continue-on-fail \
+            --release-for logos-delivery-module=${{ steps.commit.outputs.sha }} \
             --report "${{ runner.temp }}/delivery-doctest-report.html"
 
       - name: Stage report for upload

--- a/flake.nix
+++ b/flake.nix
@@ -75,7 +75,39 @@
               "$out/lib/liblogosdelivery.dylib"
           fi
         fi
-        
+
+        # librln.dylib is copied out of zerokit's output, so everything it loads
+        # by absolute store path is a dependency of zerokit and not of this
+        # module. A module travels to an app inside an LGX archive, which nix
+        # cannot scan for store paths, so nothing installs those alongside the
+        # module and the plugin fails to dlopen wherever they do not already
+        # exist. Bundle them next to librln and load them through @loader_path,
+        # the way librln and libpq already travel with the module. Transitively:
+        # the libiconv librln loads re-exports libcharset from the same path.
+        pending="$out/lib/librln.dylib"
+        while [ -n "$pending" ]; do
+          next=""
+          for macho in $pending; do
+            [ -f "$macho" ] || continue
+            chmod u+w "$macho"
+            for dep in $(otool -l "$macho" | awk '
+              $1 == "cmd" { load = ($2 ~ /^LC_(LOAD_DYLIB|LOAD_WEAK_DYLIB|REEXPORT_DYLIB)$/) }
+              load && $1 == "name" && $2 ~ "^/nix/store/" { print $2 }
+            '); do
+              name=$(basename "$dep")
+              if [ ! -f "$out/lib/$name" ]; then
+                echo "Bundling $dep as @loader_path/$name"
+                cp -L "$dep" "$out/lib/$name"
+                chmod u+w "$out/lib/$name"
+                install_name_tool -id "@loader_path/$name" "$out/lib/$name"
+                next="$next $out/lib/$name"
+              fi
+              install_name_tool -change "$dep" "@loader_path/$name" "$macho"
+            done
+          done
+          pending="$next"
+        done
+
         # Use pkg-config to locate the exact libpq from the build environment
         LIBPQ_LIBDIR=$(pkg-config --variable=libdir libpq 2>/dev/null || true)
         if [ -n "$LIBPQ_LIBDIR" ] && [ -d "$LIBPQ_LIBDIR" ]; then


### PR DESCRIPTION
## flake: bundle what librln loads

librln.dylib is copied in prebuilt from zerokit's output, so the libiconv it names by absolute store path is zerokit's dependency and not this module's. A module reaches an app inside an LGX archive, and a tar is opaque to nix's reference scanning, so that path ends up registered as a reference of nothing, ships with nothing, and the plugin fails to dlopen wherever it is absent.

That has always been true of this packaging; what changed is that runners stopped building the module. The path only ever arrived as a side effect of compiling it, since zerokit drags its own dependencies in. logos-chat-ui's macOS doc-test shows the progression across three runs of an unchanged delivery module: on 2026-07-23 it built zerokit from source and passed, on 07-27 it substituted zerokit and passed, and on 07-28 it substituted the finished .lgx, realised nothing underneath it, and failed with `Library not loaded` on that libiconv. Derivations built per run went 2875, 122, 13. A warm cache is what exposes this class, and a cold one hides it, which is why it reads as a failure out of nowhere and why bisecting over revisions could not converge.

Copy what librln loads next to it and point the load commands at @loader_path, so those libraries travel inside the archive as files rather than as references nothing carries. The walk is transitive: the libiconv librln loads re-exports libcharset from the same store path, so rewriting one level moves the dangling path down instead of removing it.

The module still shows a reference to that libiconv afterwards, because the copy names its own i18n conversion tables by absolute path. Nothing reads them here: librln imports no iconv symbol and links the library only because cargo adds it.

## ci: run the doc-test against the commit under test

The runtime doc-test builds `github:logos-co/logos-delivery-module{release}#lgx`, and with no --release-for the placeholder resolves to master, so the job installs and exercises master's module whatever the branch changed. No packaging change could ever pass or fail it. This branch demonstrated that: its first doc-test run reproduced master's dlopen failure while the commit that fixes it sat unbuilt.

Pin the placeholder to the head commit, blanking it for fork PRs whose head nix cannot fetch.

