### PR TITLE
chore: release v0.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build
 vendor/*
 lib/*
 result
+result-*
 
 # Doc-test output: generated artifacts are disposable, but keep the rendered
 # .md and the UI screenshots that the docs embed. (report.html is published by

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
     "name": "delivery_module",
-    "version": "0.1.3",
+    "version": "0.2.0",
     "description": "Logos Delivery Module - High-level message-delivery API",
     "author": "Logos Core Team",
     "type": "core",

--- a/result-main
+++ b/result-main
@@ -1,1 +1,0 @@
-/nix/store/w8qvc4scs99jhc50090nnps4qn1cc6bz-logos-delivery_module-module

--- a/tests/result-main
+++ b/tests/result-main
@@ -1,1 +1,0 @@
-/nix/store/d2zhvfpw3cc17l9cd3ds5mbdp67i8cxc-logos-delivery_module-module


### PR DESCRIPTION
Bump `metadata.json` version to 0.2.0. Draft release: https://github.com/logos-co/logos-delivery-module/releases/tag/untagged-f68a48580bcc549392fc (publish after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)