### PR TITLE
feat: expose Store queries via storeQuery

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ The delivery module provides the following API methods (all synchronous, all ret
 - `send(contentTopic: QString, payload: QString)` - Send a message (returns a request id)
 - `subscribe(contentTopic: QString)` - Subscribe to receive messages on a topic
 - `unsubscribe(contentTopic: QString)` - Unsubscribe from a topic
-- `storeQuery(jsonQuery: QString, peerAddr: QString, timeoutMs: int)` - Run a Store (historical message) query against a store service peer. Backed by the unstable liblogosdelivery kernel API; the JSON contract may change without a deprecation cycle (see the `storeQuery` doc comment in [src/delivery_module_plugin.h](src/delivery_module_plugin.h) for the query/response format)
+- `storeQuery(jsonQuery: QString, peerAddr: QString, timeoutMs: int)` - Run a Store (historical message) query against a store service peer. ⚠️ Use at your own risk: backed by the liblogosdelivery kernel API, subject to change at any point (see the `storeQuery` doc comment in [src/delivery_module_plugin.h](src/delivery_module_plugin.h) for the query/response format)
 - `getAvailableNodeInfoIDs()` - List queryable node info identifiers
 - `getNodeInfo(nodeInfoId: QString)` - Retrieve node info by identifier
 - `getAvailableConfigs()` - Retrieve available configuration parameter descriptions

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ The delivery module provides the following API methods (all synchronous, all ret
 - `send(contentTopic: QString, payload: QString)` - Send a message (returns a request id)
 - `subscribe(contentTopic: QString)` - Subscribe to receive messages on a topic
 - `unsubscribe(contentTopic: QString)` - Unsubscribe from a topic
+- `storeQuery(jsonQuery: QString, peerAddr: QString, timeoutMs: int)` - Run a Store (historical message) query against a store service peer. Backed by the unstable liblogosdelivery kernel API; the JSON contract may change without a deprecation cycle (see the `storeQuery` doc comment in [src/delivery_module_plugin.h](src/delivery_module_plugin.h) for the query/response format)
 - `getAvailableNodeInfoIDs()` - List queryable node info identifiers
 - `getNodeInfo(nodeInfoId: QString)` - Retrieve node info by identifier
 - `getAvailableConfigs()` - Retrieve available configuration parameter descriptions

--- a/result-main
+++ b/result-main
@@ -1,0 +1,1 @@
+/nix/store/w8qvc4scs99jhc50090nnps4qn1cc6bz-logos-delivery_module-module

--- a/src/delivery_module_plugin.cpp
+++ b/src/delivery_module_plugin.cpp
@@ -1,4 +1,5 @@
 #include "delivery_module_plugin.h"
+#include <algorithm>
 #include <cctype>
 #include <cstdio>
 #include <ctime>
@@ -15,6 +16,10 @@
 #include "api_call_handler.h"
 extern "C" {
 #include <liblogosdelivery.h>
+// Kernel tier: unstable, may change without a deprecation cycle. Only
+// waku_store_query is consumed from it; everything else goes through the
+// stable surface above.
+#include <liblogosdelivery_kernel.h>
 }
 
 namespace {
@@ -468,6 +473,36 @@ StdLogosResult DeliveryModuleImpl::unsubscribe(const std::string& contentTopic)
     }
 
     fprintf(stderr, "DeliveryModuleImpl: Unsubscribe completed for topic: %s with success\n", contentTopic.c_str());
+    return outcome;
+}
+
+StdLogosResult DeliveryModuleImpl::storeQuery(const std::string& jsonQuery,
+                                              const std::string& peerAddr,
+                                              int64_t timeoutMs)
+{
+    fprintf(stderr, "DeliveryModuleImpl::storeQuery called with peerAddr: %s\n", peerAddr.c_str());
+
+    if (!deliveryCtx) {
+        fprintf(stderr, "DeliveryModuleImpl: Cannot run store query - context not initialized. Call createNode first.\n");
+        return {false, {}, "Context not initialized"};
+    }
+
+    // timeoutMs bounds the query on the FFI side; wait longer than that for the
+    // completion callback so the query's own timeout error reaches the caller
+    // instead of a callback timeout.
+    auto callbackTimeout = std::max(
+        CALLBACK_TIMEOUT, std::chrono::seconds(timeoutMs / 1000 + 5));
+
+    auto outcome = callApiRetValue(
+        "store_query",
+        callbackTimeout,
+        bindApiCall(waku_store_query, deliveryCtx,
+                    jsonQuery.c_str(), peerAddr.c_str(), static_cast<int>(timeoutMs)));
+
+    if (!outcome.success) {
+        fprintf(stderr, "DeliveryModuleImpl: Store query failed for peer: %s, reason: %s\n",
+                peerAddr.c_str(), outcome.error.c_str());
+    }
     return outcome;
 }
 

--- a/src/delivery_module_plugin.h
+++ b/src/delivery_module_plugin.h
@@ -158,6 +158,45 @@ public:
     StdLogosResult unsubscribe(const std::string& contentTopic);
 
     /**
+     * @brief Runs a Store (historical message) query against a specific store
+     *        service peer.
+     *
+     * Forwards to `waku_store_query` from the kernel tier
+     * (`liblogosdelivery_kernel.h`). The kernel API is explicitly unstable and
+     * may change without a deprecation cycle; this method's JSON contract
+     * follows it.
+     *
+     * The query JSON maps to logos-delivery's `StoreQueryRequest`
+     * (`library/kernel_api/protocols/store_api.nim`):
+     * | Key                 | Type            | Required | Description                                        |
+     * |---------------------|-----------------|----------|----------------------------------------------------|
+     * | `requestId`         | string          | yes      | Caller-chosen id, echoed in the response           |
+     * | `includeData`       | boolean         | yes      | `true` returns full messages, `false` hashes only  |
+     * | `paginationForward` | boolean         | yes      | Paging direction                                   |
+     * | `pubsubTopic`       | string          | no       | Pubsub topic filter                                |
+     * | `contentTopics`     | array of string | no       | Content topic filters                              |
+     * | `timeStart`         | number/string   | no       | Range start, nanoseconds since Unix epoch          |
+     * | `timeEnd`           | number/string   | no       | Range end, nanoseconds since Unix epoch            |
+     * | `messageHashes`     | array of string | no       | Hex message hashes for lookup-by-hash queries      |
+     * | `paginationCursor`  | string          | no       | Hex cursor from a previous response                |
+     * | `paginationLimit`   | number          | no       | Max messages per page                              |
+     *
+     * On success the result value is the response JSON (`StoreQueryResponseHex`):
+     * `{ "requestId", "statusCode", "statusDesc", "messages": [ { "messageHash",
+     * "message", "pubsubTopic" } ], "paginationCursor" }` with hashes 0x-hex
+     * encoded.
+     *
+     * @param jsonQuery UTF-8 JSON query document, see above.
+     * @param peerAddr Multiaddress of the store service peer to query
+     *        (e.g. `/ip4/127.0.0.1/tcp/60000/p2p/16Uiu2...`).
+     * @param timeoutMs Query timeout in milliseconds.
+     * @return Success with the response JSON, or error details.
+     */
+    StdLogosResult storeQuery(const std::string& jsonQuery,
+                              const std::string& peerAddr,
+                              int64_t timeoutMs);
+
+    /**
      * @brief Creates (or re-opens) a reliable channel.
      *
      * Persisted channel state survives @ref channelClose, so re-creating a

--- a/src/delivery_module_plugin.h
+++ b/src/delivery_module_plugin.h
@@ -161,10 +161,9 @@ public:
      * @brief Runs a Store (historical message) query against a specific store
      *        service peer.
      *
-     * Forwards to `waku_store_query` from the kernel tier
-     * (`liblogosdelivery_kernel.h`). The kernel API is explicitly unstable and
-     * may change without a deprecation cycle; this method's JSON contract
-     * follows it.
+     * ⚠️ USE AT YOUR OWN RISK: backed by the kernel API (`waku_store_query`,
+     * `liblogosdelivery_kernel.h`), which is subject to change at any point
+     * without a deprecation cycle. This method's JSON contract follows it.
      *
      * The query JSON maps to logos-delivery's `StoreQueryRequest`
      * (`library/kernel_api/protocols/store_api.nim`):

--- a/tests/mocks/mock_liblogosdelivery.cpp
+++ b/tests/mocks/mock_liblogosdelivery.cpp
@@ -118,6 +118,13 @@ int logosdelivery_channel_close(void* /*ctx*/, logosdelivery_callback cb, void* 
     return RET_OK;
 }
 
+int waku_store_query(void* /*ctx*/, logosdelivery_callback cb, void* userData,
+                     const char* /*jsonQuery*/, const char* /*peerAddr*/, int /*timeoutMs*/) {
+    LOGOS_CMOCK_RECORD("waku_store_query");
+    invokeOk("waku_store_query", cb, userData);
+    return RET_OK;
+}
+
 int logosdelivery_get_node_info(void* /*ctx*/, logosdelivery_callback cb, void* userData, const char* /*attributeName*/) {
     LOGOS_CMOCK_RECORD("logosdelivery_get_node_info");
     invokeOk("logosdelivery_get_node_info", cb, userData);

--- a/tests/result-main
+++ b/tests/result-main
@@ -1,0 +1,1 @@
+/nix/store/d2zhvfpw3cc17l9cd3ds5mbdp67i8cxc-logos-delivery_module-module

--- a/tests/stubs/lib/liblogosdelivery_kernel.h
+++ b/tests/stubs/lib/liblogosdelivery_kernel.h
@@ -1,0 +1,34 @@
+// Stub header for liblogosdelivery_kernel - mirrors the subset of
+// library/liblogosdelivery_kernel.h from logos-delivery (master 8ad99f1) that
+// delivery_module_plugin.cpp actually consumes, so unit tests compile without
+// the real library. Keep in sync with the real header when bumping the
+// logos-delivery flake input.
+//
+// The real kernel header declares the full unstable waku_* surface; only the
+// functions used by the module are stubbed here on purpose, so an accidental
+// new kernel dependency fails loudly at compile time.
+
+#pragma once
+#ifndef __liblogosdelivery_kernel__
+#define __liblogosdelivery_kernel__
+
+// Shared FFICallBack typedef and RET_* return codes live in the stable header.
+#include "liblogosdelivery.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+  int waku_store_query(void *ctx,
+                       FFICallBack callback,
+                       void *userData,
+                       const char *jsonQuery,
+                       const char *peerAddr,
+                       int timeoutMs);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __liblogosdelivery_kernel__ */

--- a/tests/test_delivery_integration.cpp
+++ b/tests/test_delivery_integration.cpp
@@ -217,6 +217,24 @@ LOGOS_TEST(integration_subscribe_unsubscribe) {
 }
 
 // ---------------------------------------------------------------------------
+// Tests - store query
+// ---------------------------------------------------------------------------
+
+LOGOS_TEST(integration_storeQuery_reports_error_for_invalid_peer) {
+    ensureStarted();
+
+    // No store service peer is running in this environment; the point is that
+    // the real waku_store_query FFI round-trip completes and surfaces a proper
+    // error result (peer parse / query failure) instead of hanging or crashing.
+    StdLogosResult result = g_impl->storeQuery(
+        R"({"requestId":"integration-store-1","includeData":true,"paginationForward":true})",
+        "not-a-multiaddress", 3000);
+
+    LOGOS_ASSERT_FALSE(result.success);
+    LOGOS_ASSERT_FALSE(result.error.empty());
+}
+
+// ---------------------------------------------------------------------------
 // Tests - reliable channels
 // ---------------------------------------------------------------------------
 

--- a/tests/test_delivery_module.cpp
+++ b/tests/test_delivery_module.cpp
@@ -246,6 +246,37 @@ LOGOS_TEST(unsubscribe_succeeds_with_context) {
     delete impl;
 }
 
+// storeQuery
+
+LOGOS_TEST(storeQuery_fails_without_createNode) {
+    auto t = LogosTestContext("delivery_module");
+    DeliveryModuleImpl impl;
+    StdLogosResult result = impl.storeQuery(
+        R"({"requestId":"req-1","includeData":true,"paginationForward":true})",
+        "/ip4/127.0.0.1/tcp/60000/p2p/16Uiu2peer", 5000);
+    LOGOS_ASSERT_FALSE(result.success);
+    LOGOS_ASSERT_FALSE(result.error.empty());
+}
+
+LOGOS_TEST(storeQuery_returns_response_json) {
+    auto t = LogosTestContext("delivery_module");
+    auto* impl = createInitializedImpl(t);
+
+    const char* responseJson =
+        R"({"requestId":"req-1","statusCode":200,"statusDesc":"OK","messages":[]})";
+    t.mockCFunction("waku_store_query").returns(responseJson);
+
+    StdLogosResult result = impl->storeQuery(
+        R"({"requestId":"req-1","includeData":true,"paginationForward":true})",
+        "/ip4/127.0.0.1/tcp/60000/p2p/16Uiu2peer", 5000);
+
+    LOGOS_ASSERT_TRUE(result.success);
+    LOGOS_ASSERT_EQ(result.value.get<std::string>(), std::string(responseJson));
+    LOGOS_ASSERT_EQ(t.cFunctionCallCount("waku_store_query"), 1);
+
+    delete impl;
+}
+
 // channelCreate
 
 LOGOS_TEST(channelCreate_fails_without_createNode) {


### PR DESCRIPTION
Resolves #30

> [!WARNING]
> **Use at your own risk.** `storeQuery` is backed by the liblogosdelivery **kernel API**, which is subject to change at any point without a deprecation cycle. The warning is repeated in the method doc comment and README.

## What

Adds a `storeQuery(jsonQuery, peerAddr, timeoutMs)` method to `delivery_module`, exposing Store (historical message) queries through `LogosAPI` the same way `send` / `subscribe` already are — as requested in #30 for the paid Store retrieval flow in [lez-payment-streams](https://github.com/logos-co/lez-payment-streams).

## How

`liblogosdelivery` already ships `waku_store_query` — but in its **kernel tier** (`liblogosdelivery_kernel.h`), which is explicitly unstable and may change without a deprecation cycle (see logos-messaging/logos-delivery#3851 for the tiering rationale). This PR deliberately opts into that tier for this one symbol:

- `storeQuery` hands the query JSON through verbatim and returns the response JSON (`StoreQueryResponseHex`: `requestId`, `statusCode`, `statusDesc`, `messages[]`, `paginationCursor`), so the module adds no contract of its own on top of the kernel API's.
- The completion-callback wait is stretched past the caller's `timeoutMs`, so on a slow peer the caller sees the query's own timeout error rather than a generic callback timeout.
- The query/response JSON format is documented on the method doc comment (and surfaced through the generated module docs), including which fields are required (`requestId`, `includeData`, `paginationForward`).

No flake bump needed — the pinned logos-delivery revision (`8ad99f1`) already ships the kernel header and its nix package installs it.

## Tested end-to-end against the `logos.test` fleet

Portable logoscore + this module (portable layout), node created with `preset: "logos.test"`:

1. `subscribe` + `send` on `/storequery-test/1/pr76/proto` → `messagePropagated` / `messageSent` (hash `0x4974bf…1e58`);
2. `storeQuery` with `{"requestId":…,"includeData":true,"paginationForward":true,"contentTopics":[…]}` against `node-01.gc-us-central1-a.logos.test.status.im` → `statusCode: 200` with exactly that message (matching hash, payload, content topic, pubsub topic `/waku/2/rs/2/3`).

Two observations from the run, neither caused by this PR:
- Fleet health: `node-01.do-ams3` answers store queries but its archive is empty; `node-02.do-ams3` refuses connections on 30303. The other four fleet nodes serve data fine.
- Upstream response quirk: optional fields in the store response leak Nim `Opt` internals (`"oResultPrivate"` / `"vResultPrivate"` wrappers around `message`, `pubsubTopic`, `paginationCursor`) — comes verbatim from `waku_store_query`'s JSON serialization in logos-delivery. Consumers can live with it, but it's a candidate upstream fix; passing it through untouched is consistent with this method adding no contract of its own.

## Tests

- Unit: `waku_store_query` mocked; response JSON passed through, context-not-initialized rejected (`nix build .#unit-tests`).
- Integration (real liblogosdelivery): a query against an invalid peer address completes the FFI round-trip and surfaces a proper error result.
- Stub header `tests/stubs/lib/liblogosdelivery_kernel.h` mirrors only the consumed subset, so any accidental new kernel dependency fails loudly at compile time.

## Open question for reviewers

The kernel tier is "use at your own risk" by design. Exposing it through the module makes the module's `storeQuery` contract only as stable as the kernel API. Alternatives would be to wait for a stable Store surface in `liblogosdelivery.h`, or to mark the method experimental in the module metadata. Flagging explicitly since this is the first kernel-tier symbol the module consumes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
