### PR TITLE
chore: bump logos-delivery to latest master

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3824,11 +3824,11 @@
         "zerokit": "zerokit"
       },
       "locked": {
-        "lastModified": 1784801161,
-        "narHash": "sha256-9CX+nd5MQXu0xQy+HjC8CvrLG2K7RklU0dqbHIeusGU=",
+        "lastModified": 1785347810,
+        "narHash": "sha256-zuZLuAbiax49Z7crRa9ZYsY/aBM1KYItXRjqDfR7vpc=",
         "ref": "refs/heads/master",
-        "rev": "8ad99f10f41e813253ba1146efc83ca4cfdb3510",
-        "revCount": 2411,
+        "rev": "8125cd0262276c0e7927135e7e7100401f3dd611",
+        "revCount": 2418,
         "submodules": true,
         "type": "git",
         "url": "https://github.com/logos-messaging/logos-delivery"


### PR DESCRIPTION
Bumps the `logos-delivery` flake input `8ad99f1` → `8125cd0` (latest master). Notable changes pulled in:

- `logos_delivery_` metrics prefix migration (logos-messaging/logos-delivery#4074)
- Dial QUIC before TCP regardless of address list order (logos-messaging/logos-delivery#4061)
- Report the wire sender's id in `channel_message_received` (logos-messaging/logos-delivery#4073)

`nix build .#` passes with the new pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)