### PR TITLE
refactor!: drop the version() API method

### DIFF
--- a/src/delivery_module_plugin.cpp
+++ b/src/delivery_module_plugin.cpp
@@ -623,30 +623,6 @@ StdLogosResult DeliveryModuleImpl::channelClose(const std::string& channelId)
     return outcome;
 }
 
-std::string DeliveryModuleImpl::version() const {
-    std::string moduleVersion = "1.1.0";
-    if (!deliveryCtx) {
-        fprintf(stderr, "DeliveryModuleImpl: Cannot get version - context not initialized. Call createNode first.\n");
-        return moduleVersion + " (liblogosdelivery version unknown, context not initialized)";
-    }
-
-    auto liblogosDeliveryVersion = callApiRetValue(
-        "get_node_info",
-        CALLBACK_TIMEOUT,
-        bindApiCall(logosdelivery_get_node_info, deliveryCtx, "Version"));
-
-    if (!liblogosDeliveryVersion.success) {
-        fprintf(stderr, "DeliveryModuleImpl: Get node info failed getting version, reason: %s\n",
-                liblogosDeliveryVersion.error.c_str());
-        return moduleVersion + " (liblogosdelivery version unknown)";
-    }
-
-    std::string ver = liblogosDeliveryVersion.value.get<std::string>();
-    fprintf(stderr, "DeliveryModuleImpl: Get node info completed for attribute: Version, with success: %s\n", ver.c_str());
-
-    return moduleVersion + " (liblogosdelivery version: " + ver + ")";
-}
-
 StdLogosResult DeliveryModuleImpl::getAvailableNodeInfoIDs() {
     fprintf(stderr, "DeliveryModuleImpl::getAvailableNodeInfoIDs called\n");
 

--- a/src/delivery_module_plugin.h
+++ b/src/delivery_module_plugin.h
@@ -271,8 +271,6 @@ public:
 
     std::string name() const { return "delivery_module"; }
 
-    std::string version() const;
-
 logos_events:
     void messageSent(const std::string& requestId, const std::string& messageHash, int64_t timestamp);
     void messageError(const std::string& requestId, const std::string& messageHash, const std::string& error, int64_t timestamp);

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -33,7 +33,7 @@ single shard, discv5 off. The single-node lifecycle tests use one daemon each.
 |---|---|---|
 | `test_create_start_and_stop_node` | 1 | `load_module → createNode → start → stop` all succeed over RPC |
 | `test_createNode_twice_rejected` | 1 | second `createNode` returns `success=false` |
-| `test_query_and_subscribe_methods` | 1 | queries (`getAvailableConfigs`/`getAvailableNodeInfoIDs`/`getNodeInfo`/`version`) + `subscribe`/`unsubscribe` round-trip |
+| `test_query_and_subscribe_methods` | 1 | queries (`getAvailableConfigs`/`getAvailableNodeInfoIDs`/`getNodeInfo`) + `subscribe`/`unsubscribe` round-trip |
 | `test_two_nodes_propagation` | 2 | **gate** — sender sees `messagePropagated` for its `requestId` |
 | `test_bidirectional_propagation` | 2 | A→B and B→A both propagate |
 | `test_two_nodes_message_received` | 2 | receiver sees `messageReceived` (see below) |

--- a/tests/e2e/libs/helpers.py
+++ b/tests/e2e/libs/helpers.py
@@ -103,10 +103,6 @@ class LogosDelivery:
     def get_node_info(self, info_id: str, *, timeout: Optional[float] = None):
         return call_ok(self.client, "getNodeInfo", info_id, timeout=timeout)
 
-    def version(self, *, timeout: Optional[float] = None):
-        result = self.client.call(MODULE, "version", timeout=timeout)
-        return result.get("value", "") if isinstance(result, dict) else result
-
     def watch(self, event_name: str):
         return _watch_events(self.client, MODULE, event_name)
 

--- a/tests/e2e/test_node_lifecycle.py
+++ b/tests/e2e/test_node_lifecycle.py
@@ -45,6 +45,3 @@ def test_query_and_subscribe_methods(solo_daemon):
 
     delivery.subscribe(CONTENT_TOPIC)
     delivery.unsubscribe(CONTENT_TOPIC)
-
-    version = delivery.version()
-    assert isinstance(version, str) and version, f"unexpected version: {version!r}"


### PR DESCRIPTION
Removes `version()` from the module's public API.

Modules don't self-report versions — Logos Core is the authority: the version lives in the module's embedded `metadata.json` and is served by the core's module registry (`core_service.getModuleInfo("delivery_module")` under the `logoscore` daemon). Beyond the architectural point, `version()` hardcoded a stale `1.1.0` module version (metadata says otherwise), and its `liblogosdelivery` suffix duplicated what `getNodeInfo("Version")` already returns.

Changes:
- `version()` removed from `delivery_module_plugin.h` / `.cpp` — the regenerated lidl/wrappers no longer expose the method (verified: the built `module-headers-qt` output contains no `version` symbol).
- e2e: `LogosDelivery.version()` helper and its assertion in `test_node_lifecycle.py` removed; e2e README table updated.

Breaking for API consumers; the only known caller was `logos-delivery-demo`, which switches to the core-side lookup in logos-co/logos-delivery-demo#19.

Verified with a local `nix build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)