### PR TITLE
feat(windows): cross-compile for Windows, on liblogosdelivery's current C ABI

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -27,7 +27,7 @@
     "capabilities": [],
     "nix": {
         "packages": {
-            "runtime": ["postgresql", "nlohmann_json"]
+            "runtime": ["libpq", "nlohmann_json"]
         },
         "external_libraries": [
             {

--- a/src/api_call_handler.h
+++ b/src/api_call_handler.h
@@ -5,8 +5,10 @@
 #include <mutex>
 #include <semaphore>
 #include <string>
+#include <type_traits>
 #include <unordered_map>
 #include <utility>
+#include <variant>
 
 #include <logos_result.h>
 
@@ -15,143 +17,235 @@ extern "C" {
 }
 
 namespace {
-using DeliveryCallback = void (*)(int, const char*, size_t, void*);
-
 struct CallbackPayload {
     int callerRet{RET_ERR};
     std::string message;
 };
 
+// liblogosdelivery's generated C ABI has TWO reply conventions, and which one an
+// entry point uses is not a style choice we can paper over:
+//
+//   LogosDeliveryScalarRawFn      (int caller_ret, char* msg, size_t len, void*)
+//   LogosDelivery<Op>ReplyFn      (int err_code, const char* reply,
+//                                  const char* err_msg, void*)
+//
+// The first is used by the no-argument calls (start_node, stop_node,
+// get_available_*), where the payload is a pointer+length. The second is used by
+// everything that takes arguments, where success and failure text arrive in
+// SEPARATE parameters. The third parameter therefore means different things in
+// the two, which is why a single callback typedef cannot serve both.
+//
+// Argument-taking entry points also no longer take their arguments positionally:
+// each has a generated request struct (`const Logosdelivery<Op>Req*`) whose
+// fields are declared in the old positional order.
+//
+// These traits read both facts off the function pointer type, so every call site
+// keeps passing the same scalars it always did and the struct is assembled here.
+template <typename Func>
+struct ApiTraits;
+
+// Argument-taking: ...(void* ctx, Cb, void* user_data, const Req* req)
+template <typename Ret, typename Cb, typename Req>
+struct ApiTraits<Ret (*)(void*, Cb, void*, const Req*)> {
+    using callback_type = Cb;
+    using request_type = Req;
+    static constexpr bool has_request = true;
+};
+
+// No-argument: ...(void* ctx, Cb, void* user_data)
+template <typename Ret, typename Cb>
+struct ApiTraits<Ret (*)(void*, Cb, void*)> {
+    using callback_type = Cb;
+    static constexpr bool has_request = false;
+};
+
+template <typename Func>
+using ApiCallbackT = typename ApiTraits<Func>::callback_type;
+
+// Owns the request struct for the duration of the call. The generated header is
+// explicit that its strings are "borrowed, NUL-terminated const char* valid only
+// for the duration of the call they cross" -- so the struct must outlive the
+// blocking wait in callApi*, not just the invoke() that starts it. Holding it in
+// the bound object does that: the temporary lives to the end of the full
+// expression, which encloses the wait.
+template <typename Func, typename... BoundArgs>
+class BoundApiCall
+{
+public:
+    using traits = ApiTraits<Func>;
+    using callback_type = typename traits::callback_type;
+
+    BoundApiCall(Func func, void* ctx, BoundArgs&&... args)
+        : m_func(func)
+        , m_ctx(ctx)
+    {
+        if constexpr (traits::has_request) {
+            m_req = typename traits::request_type{std::forward<BoundArgs>(args)...};
+        }
+    }
+
+    int operator()(callback_type callback, void* userData)
+    {
+        if constexpr (traits::has_request) {
+            return m_func(m_ctx, callback, userData, &m_req);
+        } else {
+            return m_func(m_ctx, callback, userData);
+        }
+    }
+
+private:
+    // std::conditional_t would name `traits::request_type` even in the false
+    // branch, and the no-argument specialisation does not define it. Select the
+    // member type with a partial specialisation instead, so the lookup only
+    // happens when there IS a request struct.
+    template <typename T, bool HasRequest>
+    struct RequestMember {
+        using type = std::monostate;
+    };
+    template <typename T>
+    struct RequestMember<T, true> {
+        using type = typename T::request_type;
+    };
+
+    Func m_func;
+    void* m_ctx;
+    [[no_unique_address]] typename RequestMember<traits, traits::has_request>::type m_req{};
+};
+
 template <typename Func, typename... BoundArgs>
 auto bindApiCall(Func func, void* callbackCtx, BoundArgs&&... boundArgs)
 {
-    return [func, callbackCtx, ... args = std::forward<BoundArgs>(boundArgs)](DeliveryCallback callback, void* userData) {
-        return func(callbackCtx, callback, userData, args...);
-    };
+    return BoundApiCall<Func, BoundArgs...>(
+        func, callbackCtx, std::forward<BoundArgs>(boundArgs)...);
 }
+
+// One pending-call registry per result flavour. The callback must be a plain
+// C function pointer, so it cannot capture -- it recovers its context through
+// the user_data key instead.
+template <typename Tag>
+struct PendingRegistry {
+    struct CallbackContext {
+        std::binary_semaphore sem{0};
+        CallbackPayload payload;
+    };
+
+    static inline std::mutex mutex;
+    static inline std::unordered_map<void*, std::shared_ptr<CallbackContext>> contexts;
+
+    static void put(void* key, std::shared_ptr<CallbackContext> ctx)
+    {
+        std::lock_guard<std::mutex> lock(mutex);
+        contexts[key] = std::move(ctx);
+    }
+
+    // Take-and-erase, so a late second callback for the same key is a no-op
+    // rather than a second sem.release().
+    static std::shared_ptr<CallbackContext> take(void* key)
+    {
+        std::lock_guard<std::mutex> lock(mutex);
+        auto it = contexts.find(key);
+        if (it == contexts.end()) {
+            return nullptr;
+        }
+        auto ctx = it->second;
+        contexts.erase(it);
+        return ctx;
+    }
+
+    static void drop(void* key)
+    {
+        std::lock_guard<std::mutex> lock(mutex);
+        contexts.erase(key);
+    }
+};
+
+// Builds the reply callback for whichever convention `Cb` follows.
+//
+// ScalarRawFn carries the payload as pointer+length and uses it for both success
+// and failure text. The per-op ReplyFn splits them: `reply` is meaningful on
+// success, `err_msg` on failure -- reading the wrong one yields an empty message
+// and turns a real error into "<op> failed" with no reason, so select on
+// err_code rather than on whichever pointer happens to be non-null.
+template <typename Reg, typename Cb>
+constexpr Cb makeReplyCallback()
+{
+    if constexpr (std::is_same_v<Cb, LogosDeliveryScalarRawFn>) {
+        return +[](int callerRet, char* msg, size_t len, void* userData) {
+            auto ctx = Reg::take(userData);
+            if (!ctx) {
+                return;
+            }
+            ctx->payload.callerRet = callerRet;
+            if (msg && len > 0) {
+                ctx->payload.message.assign(msg, len);
+            }
+            ctx->sem.release();
+        };
+    } else {
+        return +[](int errCode, const char* reply, const char* errMsg, void* userData) {
+            auto ctx = Reg::take(userData);
+            if (!ctx) {
+                return;
+            }
+            ctx->payload.callerRet = errCode;
+            const char* text = (errCode == RET_OK) ? reply : errMsg;
+            if (text) {
+                ctx->payload.message.assign(text);
+            }
+            ctx->sem.release();
+        };
+    }
+}
+
+// Shared body for both flavours: register, fire, wait, translate. `wantValue`
+// only decides whether the payload text is returned or discarded.
+template <typename Tag, bool wantValue, typename BoundInvoke>
+StdLogosResult callApi(const std::string& operationName, std::chrono::seconds timeout, BoundInvoke&& invoke)
+{
+    using Reg = PendingRegistry<Tag>;
+    using Cb = typename std::decay_t<BoundInvoke>::callback_type;
+
+    auto callbackCtx = std::make_shared<typename Reg::CallbackContext>();
+    void* callbackKey = static_cast<void*>(callbackCtx.get());
+    Reg::put(callbackKey, callbackCtx);
+
+    int startResult = invoke(makeReplyCallback<Reg, Cb>(), callbackKey);
+    if (startResult != RET_OK) {
+        Reg::drop(callbackKey);
+        return {false, {}, "failed to initiate " + operationName};
+    }
+
+    if (!callbackCtx->sem.try_acquire_for(timeout)) {
+        Reg::drop(callbackKey);
+        return {false, {}, operationName + " callback timeout"};
+    }
+
+    if (callbackCtx->payload.callerRet != RET_OK) {
+        std::string message = callbackCtx->payload.message.empty()
+            ? operationName + " failed"
+            : callbackCtx->payload.message;
+        return {false, {}, message};
+    }
+
+    if constexpr (wantValue) {
+        return {true, callbackCtx->payload.message};
+    } else {
+        return {true, {}};
+    }
+}
+
+struct RetVoidTag {};
+struct RetValueTag {};
 
 template <typename BoundInvoke>
 StdLogosResult callApiRetVoid(const std::string& operationName, std::chrono::seconds timeout, BoundInvoke&& invoke)
 {
-    struct CallbackContext {
-        std::binary_semaphore sem{0};
-        CallbackPayload payload;
-    };
-
-    static std::mutex pendingMutex;
-    static std::unordered_map<void*, std::shared_ptr<CallbackContext>> pendingContexts;
-
-    auto callbackCtx = std::make_shared<CallbackContext>();
-    void* callbackKey = static_cast<void*>(callbackCtx.get());
-
-    {
-        std::lock_guard<std::mutex> lock(pendingMutex);
-        pendingContexts[callbackKey] = callbackCtx;
-    }
-
-    auto callback = +[](int callerRet, const char* msg, size_t len, void* userData) {
-        std::shared_ptr<CallbackContext> callbackCtx;
-        {
-            std::lock_guard<std::mutex> lock(pendingMutex);
-            auto it = pendingContexts.find(userData);
-            if (it == pendingContexts.end()) {
-                return;
-            }
-            callbackCtx = it->second;
-            pendingContexts.erase(it);
-        }
-
-        callbackCtx->payload.callerRet = callerRet;
-        if (msg && len > 0) {
-            callbackCtx->payload.message = std::string(msg, len);
-        }
-        callbackCtx->sem.release();
-    };
-
-    int startResult = invoke(callback, callbackKey);
-    if (startResult != RET_OK) {
-        std::lock_guard<std::mutex> lock(pendingMutex);
-        pendingContexts.erase(callbackKey);
-        return {false, {}, "failed to initiate " + operationName};
-    }
-
-    if (!callbackCtx->sem.try_acquire_for(timeout)) {
-        std::lock_guard<std::mutex> lock(pendingMutex);
-        pendingContexts.erase(callbackKey);
-        return {false, {}, operationName + " callback timeout"};
-    }
-
-    if (callbackCtx->payload.callerRet != RET_OK) {
-        std::string message = callbackCtx->payload.message.empty()
-            ? operationName + " failed"
-            : callbackCtx->payload.message;
-        return {false, {}, message};
-    }
-
-    return {true, {}};
+    return callApi<RetVoidTag, false>(operationName, timeout, std::forward<BoundInvoke>(invoke));
 }
 
 template <typename BoundInvoke>
-StdLogosResult callApiRetValue(
-    const std::string& operationName,
-    std::chrono::seconds timeout,
-    BoundInvoke&& invoke)
+StdLogosResult callApiRetValue(const std::string& operationName, std::chrono::seconds timeout, BoundInvoke&& invoke)
 {
-    struct CallbackContext {
-        std::binary_semaphore sem{0};
-        CallbackPayload payload;
-    };
-
-    static std::mutex pendingMutex;
-    static std::unordered_map<void*, std::shared_ptr<CallbackContext>> pendingContexts;
-
-    auto callbackCtx = std::make_shared<CallbackContext>();
-    void* callbackKey = static_cast<void*>(callbackCtx.get());
-
-    {
-        std::lock_guard<std::mutex> lock(pendingMutex);
-        pendingContexts[callbackKey] = callbackCtx;
-    }
-
-    auto callback = +[](int callerRet, const char* msg, size_t len, void* userData) {
-        std::shared_ptr<CallbackContext> callbackCtx;
-        {
-            std::lock_guard<std::mutex> lock(pendingMutex);
-            auto it = pendingContexts.find(userData);
-            if (it == pendingContexts.end()) {
-                return;
-            }
-            callbackCtx = it->second;
-            pendingContexts.erase(it);
-        }
-
-        callbackCtx->payload.callerRet = callerRet;
-        if (msg && len > 0) {
-            callbackCtx->payload.message = std::string(msg, len);
-        }
-        callbackCtx->sem.release();
-    };
-
-    int startResult = invoke(callback, callbackKey);
-    if (startResult != RET_OK) {
-        std::lock_guard<std::mutex> lock(pendingMutex);
-        pendingContexts.erase(callbackKey);
-        return {false, {}, "failed to initiate " + operationName};
-    }
-
-    if (!callbackCtx->sem.try_acquire_for(timeout)) {
-        std::lock_guard<std::mutex> lock(pendingMutex);
-        pendingContexts.erase(callbackKey);
-        return {false, {}, operationName + " callback timeout"};
-    }
-
-    if (callbackCtx->payload.callerRet != RET_OK) {
-        std::string message = callbackCtx->payload.message.empty()
-            ? operationName + " failed"
-            : callbackCtx->payload.message;
-        return {false, {}, message};
-    }
-
-    return {true, callbackCtx->payload.message};
+    return callApi<RetValueTag, true>(operationName, timeout, std::forward<BoundInvoke>(invoke));
 }
 } // namespace

--- a/src/delivery_module_plugin.cpp
+++ b/src/delivery_module_plugin.cpp
@@ -1,6 +1,7 @@
 #include "delivery_module_plugin.h"
 #include <algorithm>
 #include <cctype>
+#include <chrono>
 #include <cstdio>
 #include <ctime>
 #include <initializer_list>
@@ -41,9 +42,13 @@ std::vector<uint8_t> base64Decode(const std::string& encoded) {
 }
 
 int64_t currentTimestampNs() {
-    struct timespec ts;
-    clock_gettime(CLOCK_REALTIME, &ts);
-    return static_cast<int64_t>(ts.tv_sec) * 1000000000LL + static_cast<int64_t>(ts.tv_nsec);
+    // std::chrono rather than clock_gettime(CLOCK_REALTIME): the POSIX call is
+    // not available on mingw (neither the function nor CLOCK_REALTIME is
+    // declared), which broke the Windows cross-build. system_clock is the
+    // portable spelling of the same wall-clock reading.
+    return std::chrono::duration_cast<std::chrono::nanoseconds>(
+               std::chrono::system_clock::now().time_since_epoch())
+        .count();
 }
 
 // message_received: JSON array of byte values.

--- a/src/delivery_module_plugin.cpp
+++ b/src/delivery_module_plugin.cpp
@@ -13,6 +13,10 @@
 #include <semaphore>
 #include <unordered_map>
 
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
 #include <nlohmann/json.hpp>
 #include <boost/beast/core/detail/base64.hpp>
 
@@ -27,6 +31,77 @@ extern "C" {
 
 namespace {
 namespace b64 = boost::beast::detail::base64;
+
+#ifdef _WIN32
+// liblogosdelivery dlopens optional dependencies by BARE NAME -- libpq.dll for
+// the Postgres archive driver is the one that bites today:
+//
+//     DeliveryModuleImpl::createNode called
+//     could not load: libpq.dll          <- 4ms later
+//     ...createNode then never completes, and the caller sees a 20s timeout
+//
+// The Windows loader resolves a bare name against the EXECUTABLE's directory,
+// the system directories and PATH -- never against the directory of the DLL
+// doing the loading. Our libpq.dll ships INSIDE the package, next to this
+// plugin, so none of those find it.
+//
+// Copying it beside the host executable would work and is wrong: a module is
+// self-contained, and its dependencies must not have to be scattered into a
+// directory the module does not own (nor collide there with another module's
+// copy). Instead, add our own directory to the search order.
+//
+// SetDllDirectoryW rather than the alternatives:
+//   - AddDllDirectory needs SetDefaultDllDirectories(...USER_DIRS), which drops
+//     PATH from the search order process-wide -- a much larger blast radius for
+//     no gain here.
+//   - Preloading libpq.dll by full path (so a later bare-name load matches the
+//     already-loaded module) fixes exactly one library; this fixes every
+//     bare-name dependency the node may reach for.
+// It is process-global, but each module runs in its own logos_host process, so
+// the effect is scoped to this module. It also drops the CWD from the search
+// order, which is a small hardening win.
+void addOwnDirectoryToDllSearchPath()
+{
+    static std::once_flag once;
+    std::call_once(once, [] {
+        HMODULE self = nullptr;
+        if (!GetModuleHandleExW(
+                GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                reinterpret_cast<LPCWSTR>(&addOwnDirectoryToDllSearchPath),
+                &self)) {
+            fprintf(stderr, "DeliveryModuleImpl: GetModuleHandleExW failed (%lu); "
+                            "bare-name dependencies may not resolve\n", GetLastError());
+            return;
+        }
+
+        std::wstring path(MAX_PATH, L'\0');
+        for (;;) {
+            const DWORD n = GetModuleFileNameW(self, path.data(), static_cast<DWORD>(path.size()));
+            if (n == 0) {
+                fprintf(stderr, "DeliveryModuleImpl: GetModuleFileNameW failed (%lu)\n", GetLastError());
+                return;
+            }
+            if (n < path.size()) {
+                path.resize(n);
+                break;
+            }
+            path.resize(path.size() * 2);  // truncated, retry with room
+        }
+
+        const size_t slash = path.find_last_of(L"\\/");
+        if (slash == std::wstring::npos) {
+            return;
+        }
+        path.resize(slash);
+
+        if (!SetDllDirectoryW(path.c_str())) {
+            fprintf(stderr, "DeliveryModuleImpl: SetDllDirectoryW failed (%lu)\n", GetLastError());
+        }
+    });
+}
+#else
+void addOwnDirectoryToDllSearchPath() {}
+#endif
 
 std::string base64Encode(const std::vector<uint8_t>& data) {
     std::string out;
@@ -312,6 +387,11 @@ StdLogosResult DeliveryModuleImpl::createNode(const std::string& cfg)
 
     // Don't log cfg: it can carry sensitive config.
     fprintf(stderr, "DeliveryModuleImpl::createNode called\n");
+
+    // Before the node dlopens anything: liblogosdelivery reaches for optional
+    // dependencies (libpq.dll) by bare name, which the loader will not find in
+    // our own package directory without this.
+    addOwnDirectoryToDllSearchPath();
 
     auto cfgWithDefaults = applyConfigDefaults(cfg, instancePersistencePath());
     if (!cfgWithDefaults) {

--- a/src/delivery_module_plugin.cpp
+++ b/src/delivery_module_plugin.cpp
@@ -2,7 +2,9 @@
 #include <algorithm>
 #include <cctype>
 #include <chrono>
+#include <cstdint>
 #include <cstdio>
+#include <cstdlib>
 #include <ctime>
 #include <initializer_list>
 #include <memory>
@@ -80,7 +82,10 @@ std::vector<uint8_t> decodeBase64Payload(const nlohmann::json& payloadValue) {
 }
 } // namespace
 
-void DeliveryModuleImpl::start_callback(int callerRet, const char* msg, size_t len, void* userData)
+// Signature is dictated by LogosDeliveryScalarRawFn, whose payload parameter is
+// `char*` (non-const) -- start/stop keep the pointer+length convention while the
+// argument-taking entry points moved to the split reply/err_msg one.
+void DeliveryModuleImpl::start_callback(int callerRet, char* msg, size_t len, void* userData)
 {
     auto* impl = static_cast<DeliveryModuleImpl*>(userData);
     if (!impl) return;
@@ -89,7 +94,7 @@ void DeliveryModuleImpl::start_callback(int callerRet, const char* msg, size_t l
                       currentTimestampNs());
 }
 
-void DeliveryModuleImpl::stop_callback(int callerRet, const char* msg, size_t len, void* userData)
+void DeliveryModuleImpl::stop_callback(int callerRet, char* msg, size_t len, void* userData)
 {
     auto* impl = static_cast<DeliveryModuleImpl*>(userData);
     if (!impl) return;
@@ -107,7 +112,7 @@ DeliveryModuleImpl::DeliveryModuleImpl() : deliveryCtx(nullptr)
 DeliveryModuleImpl::~DeliveryModuleImpl()
 {
     if (deliveryCtx) {
-        logosdelivery_destroy(deliveryCtx, nullptr, nullptr);
+        logosdelivery_destroy(deliveryCtx);
         deliveryCtx = nullptr;
     }
 }
@@ -318,6 +323,7 @@ StdLogosResult DeliveryModuleImpl::createNode(const std::string& cfg)
         std::binary_semaphore sem{0};
         int callerRet{RET_ERR};
         std::string message;
+        void* ctx{nullptr};
     };
 
     static std::mutex pendingMutex;
@@ -331,8 +337,18 @@ StdLogosResult DeliveryModuleImpl::createNode(const std::string& cfg)
         pendingContexts[callbackKey] = callbackCtx;
     }
 
-    auto callback = +[](int callerRet, const char* msg, size_t len, void* userData) {
+    // create_node no longer RETURNS the context. It arrives here as `ctx_addr`,
+    // a decimal string holding the pointer value, and only on success -- see the
+    // generated logosdelivery_create_trampoline, which parses it the same way.
+    auto callback = +[](int callerRet, const char* ctxAddr, const char* errMsg, void* userData) {
         fprintf(stderr, "DeliveryModuleImpl::createNode callback called with ret: %d\n", callerRet);
+
+        // A progress notification, not a completion. Releasing the semaphore on
+        // it would hand createNode a context that does not exist yet; a terminal
+        // RET_OK/RET_ERR always follows.
+        if (callerRet == NIMFFI_RET_STALE_WARN) {
+            return;
+        }
 
         std::shared_ptr<CallbackContext> callbackCtx;
         {
@@ -350,15 +366,26 @@ StdLogosResult DeliveryModuleImpl::createNode(const std::string& cfg)
         }
 
         callbackCtx->callerRet = callerRet;
-        if (msg && len > 0) {
-            callbackCtx->message = std::string(msg, len);
+        if (callerRet == RET_OK) {
+            char* endp = nullptr;
+            unsigned long long addr = ctxAddr ? std::strtoull(ctxAddr, &endp, 10) : 0ULL;
+            if (ctxAddr && *ctxAddr && endp && *endp == '\0') {
+                callbackCtx->ctx = reinterpret_cast<void*>(static_cast<uintptr_t>(addr));
+            } else {
+                callbackCtx->callerRet = RET_ERR;
+                callbackCtx->message = "create returned a non-numeric context address";
+            }
+        } else if (errMsg && *errMsg) {
+            callbackCtx->message = errMsg;
             fprintf(stderr, "DeliveryModuleImpl::createNode callback message: %s\n", callbackCtx->message.c_str());
         }
 
         callbackCtx->sem.release();
     };
 
-    deliveryCtx = logosdelivery_create_node(cfgWithPorts.c_str(), callback, callbackKey);
+    LogosdeliveryCreateNodeCtorReq createReq{};
+    createReq.configJson = cfgWithPorts.c_str();
+    (void)logosdelivery_create_node(&createReq, callback, callbackKey);
 
     fprintf(stderr, "DeliveryModuleImpl: Waiting for createNode callback...\n");
 
@@ -371,6 +398,8 @@ StdLogosResult DeliveryModuleImpl::createNode(const std::string& cfg)
         fprintf(stderr, "DeliveryModuleImpl: Timeout waiting for createNode callback\n");
         return {false, {}, "Timeout waiting for createNode callback"};
     }
+
+    deliveryCtx = callbackCtx->ctx;
 
     if (callbackCtx->callerRet != RET_OK || deliveryCtx == nullptr) {
         if (!callbackCtx->message.empty()) {
@@ -385,7 +414,27 @@ StdLogosResult DeliveryModuleImpl::createNode(const std::string& cfg)
 
     fprintf(stderr, "DeliveryModuleImpl: Delivery context created successfully\n");
 
-    logosdelivery_set_event_callback(deliveryCtx, event_callback, this);
+    // The single global event callback is gone; events are delivered through a
+    // per-event-name listener registry instead. Register the same dispatcher for
+    // every name this module handles -- the payload still carries its own
+    // "eventType" field (emitEvent sends `newJsonEvent("message_received", …)`),
+    // so event_callback's existing parsing is unchanged.
+    for (const char* eventName : {
+             "onMessageSent",
+             "onMessageError",
+             "onMessagePropagated",
+             "onMessageReceived",
+             "onConnectionStatusChange",
+             "onChannelMessageReceived",
+             "onChannelMessageSent",
+             "onChannelMessageError",
+         }) {
+        if (logosdelivery_add_event_listener(deliveryCtx, eventName, event_callback, this) == 0) {
+            // A zero id means the registration did not take, which would leave
+            // this event silently undelivered for the life of the node.
+            fprintf(stderr, "DeliveryModuleImpl: failed to register listener for %s\n", eventName);
+        }
+    }
     return {true, {}};
 }
 

--- a/src/delivery_module_plugin.h
+++ b/src/delivery_module_plugin.h
@@ -303,6 +303,6 @@ private:
 
     // Completion callbacks for start()/stop(); emit nodeStarted / nodeStopped.
     // userData is the DeliveryModuleImpl*.
-    static void start_callback(int callerRet, const char* msg, size_t len, void* userData);
-    static void stop_callback(int callerRet, const char* msg, size_t len, void* userData);
+    static void start_callback(int callerRet, char* msg, size_t len, void* userData);
+    static void stop_callback(int callerRet, char* msg, size_t len, void* userData);
 };


### PR DESCRIPTION
> **Draft.** Needs logos-messaging/logos-delivery#4125 merged, then a `logos-delivery` pin bump here. The pin is deliberately left stale so this fails to compile rather than silently building against a fork — see "What this needs".

Three commits, separable:

### 1. `fix: make delivery_module cross-compile for Windows`

`nix.packages.runtime` declared `postgresql` — the *server* — which has no mingw build, so evaluation hard-failed on `meta.platforms` before anything compiled. The module never links or loads the server; it dlopens libpq. `libpq` is narrower and correct on every platform.

`currentTimestampNs()` used `clock_gettime(CLOCK_REALTIME)`, of which mingw declares neither the function nor the constant. `std::chrono::system_clock` is the portable spelling of the same reading.

### 2. `feat: migrate to liblogosdelivery's current C ABI`

The generated API moved on in four ways. Each is a compile error except the last, which is silent:

- **Arguments became request structs.** `ApiTraits` reads the request type off the function-pointer type and `BoundApiCall` assembles it, so all twelve call sites are unchanged. The struct is held by the bound object, not built inside `invoke()` — the header states its strings are *"borrowed … valid only for the duration of the call they cross"*, and the call is an async start plus a blocking wait, so it must outlive the start.
- **Two reply conventions now coexist.** No-argument calls keep `LogosDeliveryScalarRawFn` (pointer+length, one field for both outcomes); argument-taking calls use a per-op `ReplyFn` with success and failure text in *separate* parameters. Reading `reply` on a failure gives an empty string, which would turn every real error into `"<op> failed"` with no reason — so the callback selects on `err_code`.
- **`create_node` no longer returns the context.** It arrives in the callback as `ctx_addr`, a decimal string, parsed and validated as the generated trampoline does. `NIMFFI_RET_STALE_WARN` is a progress notification and must not release the semaphore.
- **The global event callback is gone**, replaced by a per-event-name registry. The payload still carries its own `eventType`, so `event_callback`'s parsing is unchanged. This is the silent one — nothing fails to compile, events simply never arrive.

### 3. `fix(windows): resolve bare-name dlopen deps from our own package`

`liblogosdelivery` dlopens `libpq.dll` by bare name, and the Windows loader never searches the calling DLL's own directory:

```
DeliveryModuleImpl::createNode called
could not load: libpq.dll          <- 4ms later
...timed out after 20000ms         <- 20s later, two layers up
```

Fixed with `SetDllDirectoryW(<own directory>)` rather than copying the DLL beside the host — a module is self-contained, and its dependencies shouldn't be scattered into a directory it doesn't own. `metadata.json`'s `include` list already stages libpq into the module dir; that satisfies import-table dependencies but not a bare-name dlopen.

## Verification

Built for `x86_64-windows` and exercised end to end in Basecamp on real Windows: node created (`createNode` ret 0 in ~8s), subscribes completing, messages sent, propagated and received over the network. The DLL fix was verified with the manual workaround **removed** from the host's `bin/`, so it tests the fix rather than the copy.

## What this needs

1. logos-messaging/logos-delivery#4125 — for the Windows cross build *and* for `generated/logosdelivery.h`, which is not emitted on any platform without it (logos-messaging/logos-delivery#4121).
2. Then bump the `logos-delivery` pin here to a rev containing it. The pin is intentionally left at v0.2.0's rev: the migrated code will not compile against it, which is the loud failure. Pointing it at a fork would build quietly and risk shipping that dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)