### PR TITLE
chore: bump logos-delivery and migrate to the nim-ffi 0.3 C ABI

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3824,11 +3824,11 @@
         "zerokit": "zerokit"
       },
       "locked": {
-        "lastModified": 1785443689,
-        "narHash": "sha256-MHPA2HSHjK6xeo+a1GrDQK80IBMmBShv7W10jZmeykI=",
+        "lastModified": 1787213774,
+        "narHash": "sha256-KaX7fDFfoSo/PKPzdRhFLksANz+qtMu2k1oyQL/zdMQ=",
         "ref": "refs/heads/master",
-        "rev": "f8b036594ea2a36b529e10b584b7d2851a3ac5c8",
-        "revCount": 2425,
+        "rev": "69fbffa3a0cfd862a2d04a4a0f57432063ecfba1",
+        "revCount": 2447,
         "submodules": true,
         "type": "git",
         "url": "https://github.com/logos-messaging/logos-delivery"

--- a/src/api_call_handler.h
+++ b/src/api_call_handler.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <atomic>
 #include <chrono>
+#include <cstdint>
 #include <memory>
 #include <mutex>
 #include <semaphore>
@@ -15,143 +17,165 @@ extern "C" {
 }
 
 namespace {
-using DeliveryCallback = void (*)(int, const char*, size_t, void*);
+// The two reply shapes of the generated C ABI. Argument-taking exports deliver
+// a typed (errCode, reply, errMsg) triple of NUL-terminated strings; the
+// no-argument "scalar fast path" exports keep the raw (callerRet, msg, len)
+// byte run. Every generated per-call typedef is an alias of one of these.
+using DeliveryReplyFn = void (*)(int, const char*, const char*, void*);
+using DeliveryScalarFn = void (*)(int, char*, size_t, void*);
 
-struct CallbackPayload {
+struct CallbackContext {
+    std::binary_semaphore sem{0};
     int callerRet{RET_ERR};
     std::string message;
 };
 
-template <typename Func, typename... BoundArgs>
-auto bindApiCall(Func func, void* callbackCtx, BoundArgs&&... boundArgs)
+// Calls waiting for a reply, keyed by the ticket handed to the FFI as userData.
+// A counter rather than the context's address: a timed-out call leaves its
+// ticket behind, and a recycled address would let that late reply wake an
+// unrelated call.
+std::mutex& pendingMutex()
 {
-    return [func, callbackCtx, ... args = std::forward<BoundArgs>(boundArgs)](DeliveryCallback callback, void* userData) {
-        return func(callbackCtx, callback, userData, args...);
+    static std::mutex mutex;
+    return mutex;
+}
+
+std::unordered_map<void*, std::shared_ptr<CallbackContext>>& pendingCalls()
+{
+    static std::unordered_map<void*, std::shared_ptr<CallbackContext>> calls;
+    return calls;
+}
+
+void* nextTicket()
+{
+    static std::atomic<uintptr_t> counter{0};
+    return reinterpret_cast<void*>(++counter);
+}
+
+// Takes the pending call off the map, so a reply that arrives twice - or after
+// the call already timed out - is dropped.
+std::shared_ptr<CallbackContext> claimCall(void* ticket)
+{
+    std::lock_guard<std::mutex> lock(pendingMutex());
+    auto it = pendingCalls().find(ticket);
+    if (it == pendingCalls().end()) {
+        return nullptr;
+    }
+    auto context = it->second;
+    pendingCalls().erase(it);
+    return context;
+}
+
+void forgetCall(void* ticket)
+{
+    std::lock_guard<std::mutex> lock(pendingMutex());
+    pendingCalls().erase(ticket);
+}
+
+// RET_STALE_WARN is a progress tick that fires every ~5s on a long call and is
+// always followed by a terminal code, so both trampolines ignore it instead of
+// completing the call.
+void replyTrampoline(int errCode, const char* reply, const char* errMsg, void* userData)
+{
+    if (errCode == RET_STALE_WARN) {
+        return;
+    }
+
+    auto context = claimCall(userData);
+    if (!context) {
+        return;
+    }
+
+    context->callerRet = errCode;
+    const char* text = (errCode == RET_OK) ? reply : errMsg;
+    if (text) {
+        context->message = text;
+    }
+    context->sem.release();
+}
+
+void scalarTrampoline(int callerRet, char* msg, size_t len, void* userData)
+{
+    if (callerRet == RET_STALE_WARN) {
+        return;
+    }
+
+    auto context = claimCall(userData);
+    if (!context) {
+        return;
+    }
+
+    context->callerRet = callerRet;
+    if (msg && len > 0) {
+        context->message.assign(msg, len);
+    }
+    context->sem.release();
+}
+
+// Binds an argument-taking export to its request struct; the generated
+// signature is func(ctx, onReply, userData, &req). `req` borrows the caller's
+// strings, so those must outlive the bound call - they do, since it runs to
+// completion inside callApiRetValue below.
+template <typename Func, typename Req>
+auto bindApiCall(Func func, void* deliveryCtx, Req req)
+{
+    return [func, deliveryCtx, req](void* ticket) {
+        return func(deliveryCtx, static_cast<DeliveryReplyFn>(replyTrampoline), ticket, &req);
     };
 }
 
-template <typename BoundInvoke>
-StdLogosResult callApiRetVoid(const std::string& operationName, std::chrono::seconds timeout, BoundInvoke&& invoke)
+// Binds a no-argument export: func(ctx, callback, userData).
+template <typename Func>
+auto bindScalarApiCall(Func func, void* deliveryCtx)
 {
-    struct CallbackContext {
-        std::binary_semaphore sem{0};
-        CallbackPayload payload;
+    return [func, deliveryCtx](void* ticket) {
+        return func(deliveryCtx, static_cast<DeliveryScalarFn>(scalarTrampoline), ticket);
     };
-
-    static std::mutex pendingMutex;
-    static std::unordered_map<void*, std::shared_ptr<CallbackContext>> pendingContexts;
-
-    auto callbackCtx = std::make_shared<CallbackContext>();
-    void* callbackKey = static_cast<void*>(callbackCtx.get());
-
-    {
-        std::lock_guard<std::mutex> lock(pendingMutex);
-        pendingContexts[callbackKey] = callbackCtx;
-    }
-
-    auto callback = +[](int callerRet, const char* msg, size_t len, void* userData) {
-        std::shared_ptr<CallbackContext> callbackCtx;
-        {
-            std::lock_guard<std::mutex> lock(pendingMutex);
-            auto it = pendingContexts.find(userData);
-            if (it == pendingContexts.end()) {
-                return;
-            }
-            callbackCtx = it->second;
-            pendingContexts.erase(it);
-        }
-
-        callbackCtx->payload.callerRet = callerRet;
-        if (msg && len > 0) {
-            callbackCtx->payload.message = std::string(msg, len);
-        }
-        callbackCtx->sem.release();
-    };
-
-    int startResult = invoke(callback, callbackKey);
-    if (startResult != RET_OK) {
-        std::lock_guard<std::mutex> lock(pendingMutex);
-        pendingContexts.erase(callbackKey);
-        return {false, {}, "failed to initiate " + operationName};
-    }
-
-    if (!callbackCtx->sem.try_acquire_for(timeout)) {
-        std::lock_guard<std::mutex> lock(pendingMutex);
-        pendingContexts.erase(callbackKey);
-        return {false, {}, operationName + " callback timeout"};
-    }
-
-    if (callbackCtx->payload.callerRet != RET_OK) {
-        std::string message = callbackCtx->payload.message.empty()
-            ? operationName + " failed"
-            : callbackCtx->payload.message;
-        return {false, {}, message};
-    }
-
-    return {true, {}};
 }
 
+// Dispatches a bound call and blocks until its reply arrives. The reply text is
+// the result value on success and the error message on failure.
 template <typename BoundInvoke>
 StdLogosResult callApiRetValue(
     const std::string& operationName,
     std::chrono::seconds timeout,
     BoundInvoke&& invoke)
 {
-    struct CallbackContext {
-        std::binary_semaphore sem{0};
-        CallbackPayload payload;
-    };
-
-    static std::mutex pendingMutex;
-    static std::unordered_map<void*, std::shared_ptr<CallbackContext>> pendingContexts;
-
-    auto callbackCtx = std::make_shared<CallbackContext>();
-    void* callbackKey = static_cast<void*>(callbackCtx.get());
+    auto context = std::make_shared<CallbackContext>();
+    void* ticket = nextTicket();
 
     {
-        std::lock_guard<std::mutex> lock(pendingMutex);
-        pendingContexts[callbackKey] = callbackCtx;
+        std::lock_guard<std::mutex> lock(pendingMutex());
+        pendingCalls()[ticket] = context;
     }
 
-    auto callback = +[](int callerRet, const char* msg, size_t len, void* userData) {
-        std::shared_ptr<CallbackContext> callbackCtx;
-        {
-            std::lock_guard<std::mutex> lock(pendingMutex);
-            auto it = pendingContexts.find(userData);
-            if (it == pendingContexts.end()) {
-                return;
-            }
-            callbackCtx = it->second;
-            pendingContexts.erase(it);
-        }
-
-        callbackCtx->payload.callerRet = callerRet;
-        if (msg && len > 0) {
-            callbackCtx->payload.message = std::string(msg, len);
-        }
-        callbackCtx->sem.release();
-    };
-
-    int startResult = invoke(callback, callbackKey);
-    if (startResult != RET_OK) {
-        std::lock_guard<std::mutex> lock(pendingMutex);
-        pendingContexts.erase(callbackKey);
+    if (invoke(ticket) != RET_OK) {
+        forgetCall(ticket);
         return {false, {}, "failed to initiate " + operationName};
     }
 
-    if (!callbackCtx->sem.try_acquire_for(timeout)) {
-        std::lock_guard<std::mutex> lock(pendingMutex);
-        pendingContexts.erase(callbackKey);
+    if (!context->sem.try_acquire_for(timeout)) {
+        forgetCall(ticket);
         return {false, {}, operationName + " callback timeout"};
     }
 
-    if (callbackCtx->payload.callerRet != RET_OK) {
-        std::string message = callbackCtx->payload.message.empty()
-            ? operationName + " failed"
-            : callbackCtx->payload.message;
-        return {false, {}, message};
+    if (context->callerRet != RET_OK) {
+        return {false, {}, context->message.empty() ? operationName + " failed" : context->message};
     }
 
-    return {true, callbackCtx->payload.message};
+    return {true, context->message};
+}
+
+template <typename BoundInvoke>
+StdLogosResult callApiRetVoid(
+    const std::string& operationName,
+    std::chrono::seconds timeout,
+    BoundInvoke&& invoke)
+{
+    auto outcome = callApiRetValue(operationName, timeout, std::forward<BoundInvoke>(invoke));
+    if (!outcome.success) {
+        return outcome;
+    }
+    return {true, {}};
 }
 } // namespace

--- a/src/delivery_module_plugin.cpp
+++ b/src/delivery_module_plugin.cpp
@@ -73,10 +73,31 @@ std::vector<uint8_t> decodeBase64Payload(const nlohmann::json& payloadValue) {
     }
     return base64Decode(payloadValue.get<std::string>());
 }
+
+// Wire names of the events this module forwards. nim-ffi 0.3.0 replaced the
+// single global event callback with a per-event listener registry, so each name
+// is registered separately; the JSON payload still carries the snake_case
+// "eventType" that event_callback dispatches on. Upstream also emits
+// onTopicHealthChange, onConnectionChange and onReceivedMessage, which the
+// module does not surface.
+constexpr const char* kEventNames[] = {
+    "onMessageSent",
+    "onMessageError",
+    "onMessagePropagated",
+    "onMessageReceived",
+    "onConnectionStatusChange",
+    "onChannelMessageReceived",
+    "onChannelMessageSent",
+    "onChannelMessageError",
+};
 } // namespace
 
-void DeliveryModuleImpl::start_callback(int callerRet, const char* msg, size_t len, void* userData)
+void DeliveryModuleImpl::start_callback(int callerRet, char* msg, size_t len, void* userData)
 {
+    if (callerRet == RET_STALE_WARN) {
+        return;
+    }
+
     auto* impl = static_cast<DeliveryModuleImpl*>(userData);
     if (!impl) return;
     impl->nodeStarted(callerRet == RET_OK,
@@ -84,8 +105,12 @@ void DeliveryModuleImpl::start_callback(int callerRet, const char* msg, size_t l
                       currentTimestampNs());
 }
 
-void DeliveryModuleImpl::stop_callback(int callerRet, const char* msg, size_t len, void* userData)
+void DeliveryModuleImpl::stop_callback(int callerRet, char* msg, size_t len, void* userData)
 {
+    if (callerRet == RET_STALE_WARN) {
+        return;
+    }
+
     auto* impl = static_cast<DeliveryModuleImpl*>(userData);
     if (!impl) return;
     impl->nodeStopped(callerRet == RET_OK,
@@ -93,7 +118,7 @@ void DeliveryModuleImpl::stop_callback(int callerRet, const char* msg, size_t le
                       currentTimestampNs());
 }
 
-DeliveryModuleImpl::DeliveryModuleImpl() : deliveryCtx(nullptr)
+DeliveryModuleImpl::DeliveryModuleImpl() : deliveryCtx(nullptr), deliveryCtxHandle(nullptr)
 {
     fprintf(stderr, "DeliveryModuleImpl: Initializing...\n");
     fprintf(stderr, "DeliveryModuleImpl: Initialized successfully\n");
@@ -101,8 +126,11 @@ DeliveryModuleImpl::DeliveryModuleImpl() : deliveryCtx(nullptr)
 
 DeliveryModuleImpl::~DeliveryModuleImpl()
 {
-    if (deliveryCtx) {
-        logosdelivery_destroy(deliveryCtx, nullptr, nullptr);
+    if (deliveryCtxHandle) {
+        // Frees the handle and stops the node, tearing down the event
+        // listeners registered against it along the way.
+        logosdelivery_ctx_destroy(static_cast<LogosDeliveryCtx*>(deliveryCtxHandle));
+        deliveryCtxHandle = nullptr;
         deliveryCtx = nullptr;
     }
 }
@@ -309,16 +337,19 @@ StdLogosResult DeliveryModuleImpl::createNode(const std::string& cfg)
     }
     const std::string& cfgWithPorts = *cfgWithDefaults;
 
-    struct CallbackContext {
+    // logosdelivery_ctx_create packs the request struct and turns the decimal
+    // context address the FFI reports back into a LogosDeliveryCtx handle.
+    struct CreateContext {
         std::binary_semaphore sem{0};
         int callerRet{RET_ERR};
         std::string message;
+        LogosDeliveryCtx* ctx{nullptr};
     };
 
     static std::mutex pendingMutex;
-    static std::unordered_map<void*, std::shared_ptr<CallbackContext>> pendingContexts;
+    static std::unordered_map<void*, std::shared_ptr<CreateContext>> pendingContexts;
 
-    auto callbackCtx = std::make_shared<CallbackContext>();
+    auto callbackCtx = std::make_shared<CreateContext>();
     void* callbackKey = static_cast<void*>(callbackCtx.get());
 
     {
@@ -326,14 +357,19 @@ StdLogosResult DeliveryModuleImpl::createNode(const std::string& cfg)
         pendingContexts[callbackKey] = callbackCtx;
     }
 
-    auto callback = +[](int callerRet, const char* msg, size_t len, void* userData) {
-        fprintf(stderr, "DeliveryModuleImpl::createNode callback called with ret: %d\n", callerRet);
+    auto callback = +[](int errCode, LogosDeliveryCtx* ctx, const char* errMsg, void* userData) {
+        fprintf(stderr, "DeliveryModuleImpl::createNode callback called with ret: %d\n", errCode);
 
-        std::shared_ptr<CallbackContext> callbackCtx;
+        std::shared_ptr<CreateContext> callbackCtx;
         {
             std::lock_guard<std::mutex> lock(pendingMutex);
             auto it = pendingContexts.find(userData);
             if (it == pendingContexts.end()) {
+                // createNode already gave up waiting. Destroy the node we were
+                // handed rather than leaving it running with no owner.
+                if (ctx) {
+                    logosdelivery_ctx_destroy(ctx);
+                }
                 return;
             }
             callbackCtx = it->second;
@@ -344,16 +380,23 @@ StdLogosResult DeliveryModuleImpl::createNode(const std::string& cfg)
             return;
         }
 
-        callbackCtx->callerRet = callerRet;
-        if (msg && len > 0) {
-            callbackCtx->message = std::string(msg, len);
-            fprintf(stderr, "DeliveryModuleImpl::createNode callback message: %s\n", callbackCtx->message.c_str());
+        callbackCtx->callerRet = errCode;
+        callbackCtx->ctx = ctx;
+        if (errCode != RET_OK && errMsg) {
+            callbackCtx->message = errMsg;
+            fprintf(stderr, "DeliveryModuleImpl::createNode callback message: %s\n", errMsg);
         }
 
         callbackCtx->sem.release();
     };
 
-    deliveryCtx = logosdelivery_create_node(cfgWithPorts.c_str(), callback, callbackKey);
+    if (logosdelivery_ctx_create(cfgWithPorts.c_str(), callback, callbackKey) != RET_OK) {
+        std::lock_guard<std::mutex> lock(pendingMutex);
+        pendingContexts.erase(callbackKey);
+
+        fprintf(stderr, "DeliveryModuleImpl: Failed to initiate createNode\n");
+        return {false, {}, "Failed to initiate createNode"};
+    }
 
     fprintf(stderr, "DeliveryModuleImpl: Waiting for createNode callback...\n");
 
@@ -361,26 +404,34 @@ StdLogosResult DeliveryModuleImpl::createNode(const std::string& cfg)
         std::lock_guard<std::mutex> lock(pendingMutex);
         pendingContexts.erase(callbackKey);
 
-        deliveryCtx = nullptr;
-
         fprintf(stderr, "DeliveryModuleImpl: Timeout waiting for createNode callback\n");
         return {false, {}, "Timeout waiting for createNode callback"};
     }
 
-    if (callbackCtx->callerRet != RET_OK || deliveryCtx == nullptr) {
+    if (callbackCtx->callerRet != RET_OK || callbackCtx->ctx == nullptr
+        || callbackCtx->ctx->ptr == nullptr) {
         if (!callbackCtx->message.empty()) {
             fprintf(stderr, "DeliveryModuleImpl: createNode callback error: %s\n", callbackCtx->message.c_str());
         }
-
-        deliveryCtx = nullptr;
+        // A handle carrying a null context is still a handle: free it.
+        if (callbackCtx->ctx) {
+            logosdelivery_ctx_destroy(callbackCtx->ctx);
+        }
 
         fprintf(stderr, "DeliveryModuleImpl: Failed to create Delivery context\n");
         return {false, {}, "Failed to create Delivery context"};
     }
 
+    deliveryCtxHandle = callbackCtx->ctx;
+    deliveryCtx = callbackCtx->ctx->ptr;
+
     fprintf(stderr, "DeliveryModuleImpl: Delivery context created successfully\n");
 
-    logosdelivery_set_event_callback(deliveryCtx, event_callback, this);
+    for (const char* eventName : kEventNames) {
+        if (logosdelivery_add_event_listener(deliveryCtx, eventName, event_callback, this) == 0) {
+            fprintf(stderr, "DeliveryModuleImpl: Failed to register listener for event %s\n", eventName);
+        }
+    }
     return {true, {}};
 }
 
@@ -433,7 +484,8 @@ StdLogosResult DeliveryModuleImpl::send(const std::string& contentTopic, const s
     auto outcome = callApiRetValue(
         "send",
         CALLBACK_TIMEOUT,
-        bindApiCall(logosdelivery_send, deliveryCtx, messageJson.c_str()));
+        bindApiCall(logosdelivery_send, deliveryCtx,
+                    LogosdeliverySendReq{.messageJson = messageJson.c_str()}));
 
     if (!outcome.success) {
         fprintf(stderr, "DeliveryModuleImpl: Send failed for topic: %s, reason: %s\n",
@@ -459,7 +511,8 @@ StdLogosResult DeliveryModuleImpl::subscribe(const std::string& contentTopic)
     auto outcome = callApiRetVoid(
         "subscribe",
         CALLBACK_TIMEOUT,
-        bindApiCall(logosdelivery_subscribe, deliveryCtx, contentTopic.c_str()));
+        bindApiCall(logosdelivery_subscribe, deliveryCtx,
+                    LogosdeliverySubscribeReq{.contentTopicStr = contentTopic.c_str()}));
 
     if (!outcome.success) {
         fprintf(stderr, "DeliveryModuleImpl: Subscribe failed for topic: %s, reason: %s\n",
@@ -482,7 +535,8 @@ StdLogosResult DeliveryModuleImpl::unsubscribe(const std::string& contentTopic)
     auto outcome = callApiRetVoid(
         "unsubscribe",
         CALLBACK_TIMEOUT,
-        bindApiCall(logosdelivery_unsubscribe, deliveryCtx, contentTopic.c_str()));
+        bindApiCall(logosdelivery_unsubscribe, deliveryCtx,
+                    LogosdeliveryUnsubscribeReq{.contentTopicStr = contentTopic.c_str()}));
 
     if (!outcome.success) {
         fprintf(stderr, "DeliveryModuleImpl: Unsubscribe failed for topic: %s, reason: %s\n",
@@ -514,7 +568,9 @@ StdLogosResult DeliveryModuleImpl::storeQuery(const std::string& jsonQuery,
         "store_query",
         callbackTimeout,
         bindApiCall(waku_store_query, deliveryCtx,
-                    jsonQuery.c_str(), peerAddr.c_str(), static_cast<int>(timeoutMs)));
+                    WakuStoreQueryReq{.jsonQuery = jsonQuery.c_str(),
+                                      .peerAddr = peerAddr.c_str(),
+                                      .timeoutMs = static_cast<int32_t>(timeoutMs)}));
 
     if (!outcome.success) {
         fprintf(stderr, "DeliveryModuleImpl: Store query failed for peer: %s, reason: %s\n",
@@ -539,7 +595,9 @@ StdLogosResult DeliveryModuleImpl::channelCreate(const std::string& channelId,
         "channel_create",
         CALLBACK_TIMEOUT,
         bindApiCall(logosdelivery_channel_create, deliveryCtx,
-                    channelId.c_str(), contentTopic.c_str(), senderId.c_str()));
+                    LogosdeliveryChannelCreateReq{.channelIdStr = channelId.c_str(),
+                                                  .contentTopicStr = contentTopic.c_str(),
+                                                  .senderIdStr = senderId.c_str()}));
 
     if (!outcome.success) {
         fprintf(stderr, "DeliveryModuleImpl: Channel create failed for id: %s, reason: %s\n",
@@ -560,7 +618,8 @@ StdLogosResult DeliveryModuleImpl::channelExists(const std::string& channelId)
     auto outcome = callApiRetValue(
         "channel_exists",
         CALLBACK_TIMEOUT,
-        bindApiCall(logosdelivery_channel_exists, deliveryCtx, channelId.c_str()));
+        bindApiCall(logosdelivery_channel_exists, deliveryCtx,
+                    LogosdeliveryChannelExistsReq{.channelIdStr = channelId.c_str()}));
 
     if (!outcome.success) {
         fprintf(stderr, "DeliveryModuleImpl: Channel exists failed for id: %s, reason: %s\n",
@@ -588,7 +647,8 @@ StdLogosResult DeliveryModuleImpl::channelSend(const std::string& channelId, con
         "channel_send",
         CALLBACK_TIMEOUT,
         bindApiCall(logosdelivery_channel_send, deliveryCtx,
-                    channelId.c_str(), messageJson.c_str()));
+                    LogosdeliveryChannelSendReq{.channelIdStr = channelId.c_str(),
+                                                .messageJson = messageJson.c_str()}));
 
     if (!outcome.success) {
         fprintf(stderr, "DeliveryModuleImpl: Channel send failed for id: %s, reason: %s\n",
@@ -614,7 +674,8 @@ StdLogosResult DeliveryModuleImpl::channelClose(const std::string& channelId)
     auto outcome = callApiRetVoid(
         "channel_close",
         CALLBACK_TIMEOUT,
-        bindApiCall(logosdelivery_channel_close, deliveryCtx, channelId.c_str()));
+        bindApiCall(logosdelivery_channel_close, deliveryCtx,
+                    LogosdeliveryChannelCloseReq{.channelIdStr = channelId.c_str()}));
 
     if (!outcome.success) {
         fprintf(stderr, "DeliveryModuleImpl: Channel close failed for id: %s, reason: %s\n",
@@ -633,7 +694,7 @@ StdLogosResult DeliveryModuleImpl::getAvailableNodeInfoIDs() {
     auto outcome = callApiRetValue(
         "get_available_node_info_ids",
         CALLBACK_TIMEOUT,
-        bindApiCall(logosdelivery_get_available_node_info_ids, deliveryCtx));
+        bindScalarApiCall(logosdelivery_get_available_node_info_ids, deliveryCtx));
 
     if (!outcome.success) {
         fprintf(stderr, "DeliveryModuleImpl: Get available node info IDs failed, reason: %s\n", outcome.error.c_str());
@@ -651,7 +712,8 @@ StdLogosResult DeliveryModuleImpl::getNodeInfo(const std::string& nodeInfoId) {
     auto outcome = callApiRetValue(
         "get_node_info",
         CALLBACK_TIMEOUT,
-        bindApiCall(logosdelivery_get_node_info, deliveryCtx, nodeInfoId.c_str()));
+        bindApiCall(logosdelivery_get_node_info, deliveryCtx,
+                    LogosdeliveryGetNodeInfoReq{.nodeInfoId = nodeInfoId.c_str()}));
 
     if (!outcome.success) {
         fprintf(stderr, "DeliveryModuleImpl: Get node info failed for ID: %s, reason: %s\n",
@@ -671,7 +733,7 @@ StdLogosResult DeliveryModuleImpl::getAvailableConfigs() {
     auto outcome = callApiRetValue(
         "get_available_configs",
         CALLBACK_TIMEOUT,
-        bindApiCall(logosdelivery_get_available_configs, deliveryCtx));
+        bindScalarApiCall(logosdelivery_get_available_configs, deliveryCtx));
 
     if (!outcome.success) {
         fprintf(stderr, "DeliveryModuleImpl: Get available configs failed, reason: %s\n", outcome.error.c_str());
@@ -691,7 +753,8 @@ std::string DeliveryModuleImpl::collectOpenMetricsText()
     auto outcome = callApiRetValue(
         "get_node_info",
         CALLBACK_TIMEOUT,
-        bindApiCall(logosdelivery_get_node_info, deliveryCtx, "Metrics"));
+        bindApiCall(logosdelivery_get_node_info, deliveryCtx,
+                    LogosdeliveryGetNodeInfoReq{.nodeInfoId = "Metrics"}));
 
     if (!outcome.success || !outcome.value.is_string()) {
         fprintf(stderr, "DeliveryModuleImpl: collectOpenMetricsText failed to read Metrics node info: %s\n",

--- a/src/delivery_module_plugin.h
+++ b/src/delivery_module_plugin.h
@@ -286,7 +286,12 @@ logos_events:
     void nodeStopped(bool success, const std::string& message, int64_t timestamp);
 
 private:
+    // Raw FFI context: what every call and the event registry take.
     void* deliveryCtx;
+    // Owning handle from logosdelivery_ctx_create (a LogosDeliveryCtx*), held
+    // as void* so the C ABI header stays out of this header's includers.
+    // Released with logosdelivery_ctx_destroy.
+    void* deliveryCtxHandle;
 
     std::mutex createNodeMutex;
 
@@ -303,6 +308,8 @@ private:
 
     // Completion callbacks for start()/stop(); emit nodeStarted / nodeStopped.
     // userData is the DeliveryModuleImpl*.
-    static void start_callback(int callerRet, const char* msg, size_t len, void* userData);
-    static void stop_callback(int callerRet, const char* msg, size_t len, void* userData);
+    // Both take the scalar-fast-path reply shape and ignore RET_STALE_WARN,
+    // the non-terminal progress tick a long start/stop emits.
+    static void start_callback(int callerRet, char* msg, size_t len, void* userData);
+    static void stop_callback(int callerRet, char* msg, size_t len, void* userData);
 };

--- a/tests/mocks/mock_liblogosdelivery.cpp
+++ b/tests/mocks/mock_liblogosdelivery.cpp
@@ -8,6 +8,10 @@
 // forget start()/stop() it means the nodeStarted/nodeStopped event is emitted
 // synchronously during the dispatch call.
 //
+// Only the symbols are shared with the plugin (extern "C", so no mangling), not
+// the declarations: request structs are taken as `const void*` since the mock
+// ignores their contents.
+//
 // Return values and callback messages are controlled via LogosCMockStore.
 // For the int-returning dispatch functions, the return value is the *dispatch*
 // code (0 / RET_OK by default); set a non-zero value to simulate a dispatch
@@ -15,131 +19,163 @@
 //   t.mockCFunction("logosdelivery_start_node").returns(1);  // dispatch fails
 
 #include <logos_clib_mock.h>
+#include <cstdint>
+#include <cstdio>
 #include <cstring>
 
 #define RET_OK  0
 #define RET_ERR 1
 
-typedef void (*logosdelivery_callback)(int callerRet, const char* msg, size_t len, void* userData);
+// Argument-taking exports: NUL-terminated reply and error strings.
+typedef void (*logosdelivery_reply)(int errCode, const char* reply, const char* errMsg, void* userData);
+// No-argument "scalar fast path" exports: raw byte run.
+typedef void (*logosdelivery_scalar)(int callerRet, char* msg, size_t len, void* userData);
+// Constructor: the context address as decimal text.
+typedef void (*logosdelivery_create)(int errCode, const char* ctxAddr, const char* errMsg, void* userData);
+// Event listeners.
+typedef void (*logosdelivery_event)(int callerRet, const char* msg, size_t len, void* userData);
 
 // Sentinel address used as a fake non-null delivery context.
 static char s_fakeCtx = 0;
 
-// Helper: invoke callback with RET_OK and the string configured in the mock store.
-static void invokeOk(const char* funcName, logosdelivery_callback cb, void* userData) {
-    if (!cb) return;
+// Helper: reply RET_OK with the string configured in the mock store.
+static void replyOk(const char* funcName, logosdelivery_reply onReply, void* userData) {
+    if (!onReply) return;
     const char* msg = LogosCMockStore::instance().getReturnString(funcName);
-    cb(RET_OK, msg ? msg : "", msg ? strlen(msg) : 0, userData);
+    onReply(RET_OK, msg ? msg : "", "", userData);
+}
+
+static void scalarOk(const char* funcName, logosdelivery_scalar callback, void* userData) {
+    if (!callback) return;
+    const char* msg = LogosCMockStore::instance().getReturnString(funcName);
+    // The real ABI hands out a mutable, non-NUL-terminated buffer; copy so the
+    // callback cannot observe the store's storage.
+    char buffer[4096];
+    size_t len = msg ? strnlen(msg, sizeof(buffer)) : 0;
+    if (len > 0) memcpy(buffer, msg, len);
+    callback(RET_OK, buffer, len, userData);
 }
 
 extern "C" {
 
-void* logosdelivery_create_node(const char* /*cfg*/, logosdelivery_callback cb, void* userData) {
+void* logosdelivery_create_node(const void* /*req*/, logosdelivery_create onCreated, void* userData) {
     LOGOS_CMOCK_RECORD("logosdelivery_create_node");
     int ok = LOGOS_CMOCK_RETURN(int, "logosdelivery_create_node");
-    if (ok && cb) {
-        cb(RET_OK, "", 0, userData);
-    } else if (!ok && cb) {
-        cb(RET_ERR, "mock: create_node fail", 22, userData);
+    if (onCreated) {
+        if (ok) {
+            // The real constructor reports the context as decimal text.
+            char addr[32];
+            snprintf(addr, sizeof(addr), "%llu",
+                     static_cast<unsigned long long>(reinterpret_cast<uintptr_t>(&s_fakeCtx)));
+            onCreated(RET_OK, addr, "", userData);
+        } else {
+            onCreated(RET_ERR, "", "mock: create_node fail", userData);
+        }
     }
-    return ok ? static_cast<void*>(&s_fakeCtx) : nullptr;
+    // Upstream reports the context through the callback, not the return value.
+    return nullptr;
 }
 
-void logosdelivery_set_event_callback(void* /*ctx*/, logosdelivery_callback /*cb*/, void* /*userData*/) {
-    LOGOS_CMOCK_RECORD("logosdelivery_set_event_callback");
+uint64_t logosdelivery_add_event_listener(void* /*ctx*/, const char* /*eventName*/,
+                                          logosdelivery_event /*cb*/, void* /*userData*/) {
+    LOGOS_CMOCK_RECORD("logosdelivery_add_event_listener");
+    // Non-zero: a valid listener id.
+    return 1;
 }
 
-int logosdelivery_destroy(void* /*ctx*/, logosdelivery_callback /*cb*/, void* /*userData*/) {
+int logosdelivery_remove_event_listener(void* /*ctx*/, uint64_t /*listenerId*/) {
+    LOGOS_CMOCK_RECORD("logosdelivery_remove_event_listener");
+    return RET_OK;
+}
+
+int logosdelivery_destroy(void* /*ctx*/) {
     LOGOS_CMOCK_RECORD("logosdelivery_destroy");
     return RET_OK;
 }
 
-int logosdelivery_start_node(void* /*ctx*/, logosdelivery_callback cb, void* userData) {
+int logosdelivery_start_node(void* /*ctx*/, logosdelivery_scalar cb, void* userData) {
     LOGOS_CMOCK_RECORD("logosdelivery_start_node");
     // Return value is the dispatch code (default 0 = RET_OK). Only fire the
     // completion callback when dispatch "succeeds", mirroring the real FFI.
     int dispatch = LOGOS_CMOCK_RETURN(int, "logosdelivery_start_node");
     if (dispatch == RET_OK) {
-        invokeOk("logosdelivery_start_node", cb, userData);
+        scalarOk("logosdelivery_start_node", cb, userData);
     }
     return dispatch;
 }
 
-int logosdelivery_stop_node(void* /*ctx*/, logosdelivery_callback cb, void* userData) {
+int logosdelivery_stop_node(void* /*ctx*/, logosdelivery_scalar cb, void* userData) {
     LOGOS_CMOCK_RECORD("logosdelivery_stop_node");
     int dispatch = LOGOS_CMOCK_RETURN(int, "logosdelivery_stop_node");
     if (dispatch == RET_OK) {
-        invokeOk("logosdelivery_stop_node", cb, userData);
+        scalarOk("logosdelivery_stop_node", cb, userData);
     }
     return dispatch;
 }
 
-int logosdelivery_send(void* /*ctx*/, logosdelivery_callback cb, void* userData, const char* /*msg*/) {
+int logosdelivery_send(void* /*ctx*/, logosdelivery_reply onReply, void* userData, const void* /*req*/) {
     LOGOS_CMOCK_RECORD("logosdelivery_send");
-    invokeOk("logosdelivery_send", cb, userData);
+    replyOk("logosdelivery_send", onReply, userData);
     return RET_OK;
 }
 
-int logosdelivery_subscribe(void* /*ctx*/, logosdelivery_callback cb, void* userData, const char* /*topic*/) {
+int logosdelivery_subscribe(void* /*ctx*/, logosdelivery_reply onReply, void* userData, const void* /*req*/) {
     LOGOS_CMOCK_RECORD("logosdelivery_subscribe");
-    invokeOk("logosdelivery_subscribe", cb, userData);
+    replyOk("logosdelivery_subscribe", onReply, userData);
     return RET_OK;
 }
 
-int logosdelivery_unsubscribe(void* /*ctx*/, logosdelivery_callback cb, void* userData, const char* /*topic*/) {
+int logosdelivery_unsubscribe(void* /*ctx*/, logosdelivery_reply onReply, void* userData, const void* /*req*/) {
     LOGOS_CMOCK_RECORD("logosdelivery_unsubscribe");
-    invokeOk("logosdelivery_unsubscribe", cb, userData);
+    replyOk("logosdelivery_unsubscribe", onReply, userData);
     return RET_OK;
 }
 
-int logosdelivery_channel_create(void* /*ctx*/, logosdelivery_callback cb, void* userData,
-                                 const char* /*channelId*/, const char* /*contentTopic*/, const char* /*senderId*/) {
+int logosdelivery_channel_create(void* /*ctx*/, logosdelivery_reply onReply, void* userData, const void* /*req*/) {
     LOGOS_CMOCK_RECORD("logosdelivery_channel_create");
-    invokeOk("logosdelivery_channel_create", cb, userData);
+    replyOk("logosdelivery_channel_create", onReply, userData);
     return RET_OK;
 }
 
-int logosdelivery_channel_exists(void* /*ctx*/, logosdelivery_callback cb, void* userData, const char* /*channelId*/) {
+int logosdelivery_channel_exists(void* /*ctx*/, logosdelivery_reply onReply, void* userData, const void* /*req*/) {
     LOGOS_CMOCK_RECORD("logosdelivery_channel_exists");
-    invokeOk("logosdelivery_channel_exists", cb, userData);
+    replyOk("logosdelivery_channel_exists", onReply, userData);
     return RET_OK;
 }
 
-int logosdelivery_channel_send(void* /*ctx*/, logosdelivery_callback cb, void* userData,
-                               const char* /*channelId*/, const char* /*msg*/) {
+int logosdelivery_channel_send(void* /*ctx*/, logosdelivery_reply onReply, void* userData, const void* /*req*/) {
     LOGOS_CMOCK_RECORD("logosdelivery_channel_send");
-    invokeOk("logosdelivery_channel_send", cb, userData);
+    replyOk("logosdelivery_channel_send", onReply, userData);
     return RET_OK;
 }
 
-int logosdelivery_channel_close(void* /*ctx*/, logosdelivery_callback cb, void* userData, const char* /*channelId*/) {
+int logosdelivery_channel_close(void* /*ctx*/, logosdelivery_reply onReply, void* userData, const void* /*req*/) {
     LOGOS_CMOCK_RECORD("logosdelivery_channel_close");
-    invokeOk("logosdelivery_channel_close", cb, userData);
+    replyOk("logosdelivery_channel_close", onReply, userData);
     return RET_OK;
 }
 
-int waku_store_query(void* /*ctx*/, logosdelivery_callback cb, void* userData,
-                     const char* /*jsonQuery*/, const char* /*peerAddr*/, int /*timeoutMs*/) {
+int waku_store_query(void* /*ctx*/, logosdelivery_reply onReply, void* userData, const void* /*req*/) {
     LOGOS_CMOCK_RECORD("waku_store_query");
-    invokeOk("waku_store_query", cb, userData);
+    replyOk("waku_store_query", onReply, userData);
     return RET_OK;
 }
 
-int logosdelivery_get_node_info(void* /*ctx*/, logosdelivery_callback cb, void* userData, const char* /*attributeName*/) {
+int logosdelivery_get_node_info(void* /*ctx*/, logosdelivery_reply onReply, void* userData, const void* /*req*/) {
     LOGOS_CMOCK_RECORD("logosdelivery_get_node_info");
-    invokeOk("logosdelivery_get_node_info", cb, userData);
+    replyOk("logosdelivery_get_node_info", onReply, userData);
     return RET_OK;
 }
 
-int logosdelivery_get_available_node_info_ids(void* /*ctx*/, logosdelivery_callback cb, void* userData) {
+int logosdelivery_get_available_node_info_ids(void* /*ctx*/, logosdelivery_scalar cb, void* userData) {
     LOGOS_CMOCK_RECORD("logosdelivery_get_available_node_info_ids");
-    invokeOk("logosdelivery_get_available_node_info_ids", cb, userData);
+    scalarOk("logosdelivery_get_available_node_info_ids", cb, userData);
     return RET_OK;
 }
 
-int logosdelivery_get_available_configs(void* /*ctx*/, logosdelivery_callback cb, void* userData) {
+int logosdelivery_get_available_configs(void* /*ctx*/, logosdelivery_scalar cb, void* userData) {
     LOGOS_CMOCK_RECORD("logosdelivery_get_available_configs");
-    invokeOk("logosdelivery_get_available_configs", cb, userData);
+    scalarOk("logosdelivery_get_available_configs", cb, userData);
     return RET_OK;
 }
 

--- a/tests/stubs/lib/liblogosdelivery.h
+++ b/tests/stubs/lib/liblogosdelivery.h
@@ -1,12 +1,17 @@
-// Stub header for liblogosdelivery - mirrors library/liblogosdelivery.h from
-// logos-delivery (master 8ad99f1) so that delivery_module_plugin.cpp compiles
-// during unit tests without the real library. Keep in sync with the real,
-// Nim-build-generated header when bumping the logos-delivery flake input.
+// Stub header for liblogosdelivery - mirrors the subset of the Nim-generated
+// C ABI from logos-delivery (master 69fbffa3) that delivery_module_plugin.cpp
+// consumes, so it compiles during unit tests without the real library. Keep in
+// sync with the real, Nim-build-generated header when bumping the
+// logos-delivery flake input.
 //
-// Note on the channel-events comment below: "onChannelMessageReceived/Sent/
-// Error" are upstream's internal listener labels; the JSON "eventType" values
-// actually delivered to the event callback are "channel_message_received",
-// "channel_message_sent" and "channel_message_error" (see node_api.nim).
+// Upstream splits this across library/liblogosdelivery.h (event ABI) and the
+// generated generated/logosdelivery.h (call surface plus the logosdelivery_ctx_*
+// convenience wrapper); both are folded into this one file.
+//
+// Note on the event names below: they are the wire names of upstream's
+// per-event listener registry. The JSON "eventType" values actually delivered
+// to the event callback are the snake_case ones - "channel_message_received",
+// "channel_message_sent", "channel_message_error" and friends (see node_api.nim).
 
 #pragma once
 #ifndef __liblogosdelivery__
@@ -14,22 +19,96 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
 
 // The possible returned values for the functions that return int
-#define RET_OK 0
-#define RET_ERR 1
-#define RET_MISSING_CALLBACK 2
+#define NIMFFI_RET_OK 0
+#define NIMFFI_RET_ERR 1
+#define NIMFFI_RET_MISSING_CALLBACK 2
+// Non-terminal: the request is still running. Fires every ~5s and is always
+// followed by a terminal RET_OK/RET_ERR.
+#define NIMFFI_RET_STALE_WARN 3
+#define RET_OK NIMFFI_RET_OK
+#define RET_ERR NIMFFI_RET_ERR
+#define RET_MISSING_CALLBACK NIMFFI_RET_MISSING_CALLBACK
+#define RET_STALE_WARN NIMFFI_RET_STALE_WARN
+
+// `abi = c` wire structs. Strings are borrowed, NUL-terminated `const char*`
+// valid only for the duration of the call they cross.
+typedef struct {
+    const char* configJson;
+} LogosdeliveryCreateNodeCtorReq;
+typedef struct {
+    const char* contentTopicStr;
+} LogosdeliverySubscribeReq;
+typedef struct {
+    const char* contentTopicStr;
+} LogosdeliveryUnsubscribeReq;
+typedef struct {
+    // { "contentTopic": ..., "payload": <base64>, "ephemeral": <bool> }
+    const char* messageJson;
+} LogosdeliverySendReq;
+typedef struct {
+    const char* nodeInfoId;
+} LogosdeliveryGetNodeInfoReq;
+typedef struct {
+    const char* channelIdStr;
+    const char* contentTopicStr;
+    const char* senderIdStr;
+} LogosdeliveryChannelCreateReq;
+typedef struct {
+    const char* channelIdStr;
+} LogosdeliveryChannelExistsReq;
+typedef struct {
+    const char* channelIdStr;
+    // { "payload": <base64>, "ephemeral": <bool> }
+    const char* messageJson;
+} LogosdeliveryChannelSendReq;
+typedef struct {
+    const char* channelIdStr;
+} LogosdeliveryChannelCloseReq;
+
+// Argument-taking exports all share this reply shape; upstream emits one
+// typedef per call, which this stub collapses into a single name.
+typedef void (*LogosDeliveryReplyFn)(int err_code,
+                                     const char* reply,
+                                     const char* err_msg,
+                                     void* user_data);
+
+// Raw reply of a scalar-fast-path export: `msg`/`len` are bytes, not
+// NUL-terminated, and valid only for the duration of the call.
+typedef void (*LogosDeliveryScalarRawFn)(int caller_ret, char* msg, size_t len, void* user_data);
+
+// Raw reply of the constructor: `ctx_addr` is the context address as decimal text.
+typedef void (*LogosDeliveryCreateRawFn)(int err_code,
+                                         const char* ctx_addr,
+                                         const char* err_msg,
+                                         void* user_data);
+
+// NUL-terminated copy of a length-delimited byte run; NULL if it can't.
+static inline char* nimffi_abi_dup_cstr_n(const char* s, size_t n) {
+    if (n == SIZE_MAX) return NULL;
+    char* p = (char*)malloc(n + 1);
+    if (p) {
+        if (n > 0) memcpy(p, s, n);
+        p[n] = '\0';
+    }
+    return p;
+}
 
 #ifdef __cplusplus
 extern "C"
 {
 #endif
 
+  // Raw result-delivery callback used by the event API. `msg` is a byte run of
+  // `len` bytes, not NUL-terminated, valid only for the duration of the call.
   typedef void (*FFICallBack)(int callerRet, const char *msg, size_t len, void *userData);
 
-  // Creates a new instance of the node from the given configuration JSON.
-  // Returns a pointer to the Context needed by the rest of the API functions.
-  // The configuration is a JSON object with these optional keys:
+  // Creates a new node from the given configuration JSON and reports the
+  // context address through `on_created`. The configuration is a JSON object
+  // with these optional keys:
   //   "mode": "Core" | "Edge"        (messaging role; defaults to "Core")
   //   "preset": "<network preset>"   (e.g. "twn")
   //   "messagingOverrides": { ... }  (per-field messaging config overrides)
@@ -37,110 +116,76 @@ extern "C"
   // Override keys accept the config field name or its CLI switch name (e.g.
   // "clusterId" or "cluster-id"). Unknown keys are rejected.
   // Example: {"mode":"Core","messagingOverrides":{"cluster-id":42,"log-level":"INFO"}}
-  void *logosdelivery_create_node(
-      const char *configJson,
-      FFICallBack callback,
-      void *userData);
+  void *logosdelivery_create_node(const LogosdeliveryCreateNodeCtorReq *req,
+                                  LogosDeliveryCreateRawFn on_created,
+                                  void *user_data);
 
   // Starts the node.
-  int logosdelivery_start_node(void *ctx,
-                       FFICallBack callback,
-                       void *userData);
+  int logosdelivery_start_node(void *ctx, LogosDeliveryScalarRawFn callback, void *user_data);
 
   // Stops the node.
-  int logosdelivery_stop_node(void *ctx,
-                      FFICallBack callback,
-                      void *userData);
+  int logosdelivery_stop_node(void *ctx, LogosDeliveryScalarRawFn callback, void *user_data);
 
-  // Destroys an instance of a node created with logosdelivery_create_node
-  int logosdelivery_destroy(void *ctx,
-                    FFICallBack callback,
-                    void *userData);
+  // Destroys a node created with logosdelivery_create_node, tearing down the
+  // event listeners registered against it.
+  int logosdelivery_destroy(void *ctx);
 
-  // Subscribe to a content topic.
-  // contentTopic: string representing the content topic (e.g., "/myapp/1/chat/proto")
-  int logosdelivery_subscribe(void *ctx,
-                      FFICallBack callback,
-                      void *userData,
-                      const char *contentTopic);
+  // Subscribe to / unsubscribe from a content topic
+  // (e.g. "/myapp/1/chat/proto").
+  int logosdelivery_subscribe(void *ctx, LogosDeliveryReplyFn on_reply, void *user_data,
+                              const LogosdeliverySubscribeReq *req);
+  int logosdelivery_unsubscribe(void *ctx, LogosDeliveryReplyFn on_reply, void *user_data,
+                                const LogosdeliveryUnsubscribeReq *req);
 
-  // Unsubscribe from a content topic.
-  int logosdelivery_unsubscribe(void *ctx,
-                        FFICallBack callback,
-                        void *userData,
-                        const char *contentTopic);
-
-  // Send a message.
-  // messageJson: JSON string with the following structure:
-  // {
-  //   "contentTopic": "/myapp/1/chat/proto",
-  //   "payload": "base64-encoded-payload",
-  //   "ephemeral": false
-  // }
-  // Returns a request ID that can be used to track the message delivery.
-  int logosdelivery_send(void *ctx,
-                 FFICallBack callback,
-                 void *userData,
-                 const char *messageJson);
+  // Send a message. Replies with a request ID that tracks its delivery.
+  int logosdelivery_send(void *ctx, LogosDeliveryReplyFn on_reply, void *user_data,
+                         const LogosdeliverySendReq *req);
 
   // --- Reliable Channels API (stable surface) ---
 
-  // Create a reliable channel. Returns the channel id.
-  int logosdelivery_channel_create(void *ctx,
-                           FFICallBack callback,
-                           void *userData,
-                           const char *channelId,
-                           const char *contentTopic,
-                           const char *senderId);
+  // Create a reliable channel. Replies with the channel id.
+  int logosdelivery_channel_create(void *ctx, LogosDeliveryReplyFn on_reply, void *user_data,
+                                   const LogosdeliveryChannelCreateReq *req);
 
-  // Check whether a reliable channel is currently open. Returns "true" or
-  // "false"; an unknown channel id is not an error.
-  int logosdelivery_channel_exists(void *ctx,
-                           FFICallBack callback,
-                           void *userData,
-                           const char *channelId);
+  // Replies "true" or "false"; an unknown channel id is not an error.
+  int logosdelivery_channel_exists(void *ctx, LogosDeliveryReplyFn on_reply, void *user_data,
+                                   const LogosdeliveryChannelExistsReq *req);
 
-  // Send a message on a reliable channel.
-  // messageJson: { "payload": "base64-encoded-payload", "ephemeral": false }
-  // Returns a request ID that can be used to track delivery.
-  int logosdelivery_channel_send(void *ctx,
-                         FFICallBack callback,
-                         void *userData,
-                         const char *channelId,
-                         const char *messageJson);
+  // Send a message on a reliable channel. Replies with a request ID.
+  int logosdelivery_channel_send(void *ctx, LogosDeliveryReplyFn on_reply, void *user_data,
+                                 const LogosdeliveryChannelSendReq *req);
 
   // Close a reliable channel: stops its SDS loops; persisted state survives, so
   // re-creating the channel restores it.
-  int logosdelivery_channel_close(void *ctx,
-                          FFICallBack callback,
-                          void *userData,
-                          const char *channelId);
+  int logosdelivery_channel_close(void *ctx, LogosDeliveryReplyFn on_reply, void *user_data,
+                                  const LogosdeliveryChannelCloseReq *req);
 
-  // Channel lifecycle events are delivered through the event callback set via
-  // logosdelivery_set_event_callback: "onChannelMessageReceived" (payload
-  // base64-encoded), "onChannelMessageSent", "onChannelMessageError".
+  // --- Events ---
 
-  // Sets a callback that will be invoked whenever an event occurs.
-  // It is crucial that the passed callback is fast, non-blocking and potentially thread-safe.
-  void logosdelivery_set_event_callback(void *ctx,
-                                 FFICallBack callback,
-                                 void *userData);
+  // Events are delivered through a per-event listener registry: one callback
+  // per event name. Names: "onMessageSent", "onMessageError",
+  // "onMessagePropagated", "onMessageReceived", "onConnectionStatusChange",
+  // "onTopicHealthChange", "onConnectionChange", "onReceivedMessage",
+  // "onChannelMessageReceived" (payload base64-encoded), "onChannelMessageSent"
+  // and "onChannelMessageError".
+  //
+  // Returns a non-zero listener id (0 on an invalid context). The callback runs
+  // on a dedicated event thread and must be fast, non-blocking and thread-safe.
+  uint64_t logosdelivery_add_event_listener(void *ctx, const char *eventName,
+                                            FFICallBack callback, void *userData);
 
-  // Retrieves the list of available node info IDs.
-  int logosdelivery_get_available_node_info_ids(void *ctx,
-                                 FFICallBack callback,
-                                 void *userData);
+  // Removes a previously registered listener. Returns 0 on success, 1 if the
+  // listener id was not found or the context is invalid.
+  int logosdelivery_remove_event_listener(void *ctx, uint64_t listenerId);
 
-  // Given a node info ID, retrieves the corresponding info.
-  int logosdelivery_get_node_info(void *ctx,
-                                  FFICallBack callback,
-                                  void *userData,
-                                  const char *nodeInfoId);
+  // --- Node info / config introspection ---
 
-  // Retrieves the list of available configurations.
-  int logosdelivery_get_available_configs(void *ctx,
-                                    FFICallBack callback,
-                                    void *userData);
+  int logosdelivery_get_available_node_info_ids(void *ctx, LogosDeliveryScalarRawFn callback,
+                                                void *user_data);
+  int logosdelivery_get_node_info(void *ctx, LogosDeliveryReplyFn on_reply, void *user_data,
+                                  const LogosdeliveryGetNodeInfoReq *req);
+  int logosdelivery_get_available_configs(void *ctx, LogosDeliveryScalarRawFn callback,
+                                          void *user_data);
 
   // NOTE: the low-level kernel API (waku_*) lives in the separate, advanced
   // header liblogosdelivery_kernel.h. It is intentionally not declared here so
@@ -149,5 +194,73 @@ extern "C"
 #ifdef __cplusplus
 }
 #endif
+
+// --- High-level context wrapper ---
+//
+// Mirrors the inline wrapper upstream generates alongside the raw ABI. Only the
+// constructor and destructor are reproduced: those are the two the module uses,
+// because they are what turns the decimal context address into a handle.
+
+typedef struct {
+    void* ptr;
+} LogosDeliveryCtx;
+
+typedef void (*LogosDeliveryCreateFn)(int err_code, LogosDeliveryCtx* ctx,
+                                      const char* err_msg, void* user_data);
+typedef struct { LogosDeliveryCreateFn fn; void* user_data; } LogosDeliveryCreateBox;
+
+static inline void logosdelivery_create_trampoline(int ret, const char* ctx_addr,
+                                                   const char* err_msg, void* ud) {
+    LogosDeliveryCreateBox* box = (LogosDeliveryCreateBox*)ud;
+    if (!box) return;
+    if (ret == NIMFFI_RET_STALE_WARN) return;
+    if (!box->fn) { free(box); return; }
+    if (ret != 0) {
+        box->fn(ret, NULL, err_msg ? err_msg : "FFI create failed", box->user_data);
+        free(box);
+        return;
+    }
+    char* endp = NULL;
+    unsigned long long a = ctx_addr ? strtoull(ctx_addr, &endp, 10) : 0;
+    int ok = ctx_addr && *ctx_addr && endp && *endp == '\0';
+    if (!ok) {
+        box->fn(-1, NULL, "FFI create returned non-numeric address", box->user_data);
+        free(box);
+        return;
+    }
+    LogosDeliveryCtx* ctx = (LogosDeliveryCtx*)calloc(1, sizeof(LogosDeliveryCtx));
+    if (!ctx) {
+        box->fn(-1, NULL, "out of memory", box->user_data);
+        free(box);
+        return;
+    }
+    ctx->ptr = (void*)(uintptr_t)a;
+    box->fn(NIMFFI_RET_OK, ctx, NULL, box->user_data);
+    free(box);
+}
+
+static inline int logosdelivery_ctx_create(const char* configJson,
+                                           LogosDeliveryCreateFn on_created, void* user_data) {
+    LogosdeliveryCreateNodeCtorReq ffi_req;
+    memset(&ffi_req, 0, sizeof(ffi_req));
+    ffi_req.configJson = configJson;
+    LogosDeliveryCreateBox* box = (LogosDeliveryCreateBox*)malloc(sizeof(LogosDeliveryCreateBox));
+    if (!box) {
+        if (on_created) on_created(-1, NULL, "out of memory", user_data);
+        return -1;
+    }
+    box->fn = on_created;
+    box->user_data = user_data;
+    (void)logosdelivery_create_node(&ffi_req, logosdelivery_create_trampoline, box);
+    return 0;
+}
+
+static inline int logosdelivery_ctx_destroy(LogosDeliveryCtx* ctx) {
+    if (!ctx) return NIMFFI_RET_OK;
+    int rc = NIMFFI_RET_OK;
+    if (ctx->ptr) { rc = logosdelivery_destroy(ctx->ptr); ctx->ptr = NULL; }
+    free(ctx);
+    return rc;
+}
 
 #endif /* __liblogosdelivery__ */

--- a/tests/stubs/lib/liblogosdelivery_kernel.h
+++ b/tests/stubs/lib/liblogosdelivery_kernel.h
@@ -1,5 +1,5 @@
-// Stub header for liblogosdelivery_kernel - mirrors the subset of
-// library/liblogosdelivery_kernel.h from logos-delivery (master 8ad99f1) that
+// Stub header for liblogosdelivery_kernel - mirrors the subset of the
+// generated waku_* surface from logos-delivery (master 69fbffa3) that
 // delivery_module_plugin.cpp actually consumes, so unit tests compile without
 // the real library. Keep in sync with the real header when bumping the
 // logos-delivery flake input.
@@ -12,8 +12,14 @@
 #ifndef __liblogosdelivery_kernel__
 #define __liblogosdelivery_kernel__
 
-// Shared FFICallBack typedef and RET_* return codes live in the stable header.
+// Shared reply typedefs and RET_* return codes live in the stable header.
 #include "liblogosdelivery.h"
+
+typedef struct {
+    const char* jsonQuery;
+    const char* peerAddr;
+    int32_t timeoutMs;
+} WakuStoreQueryReq;
 
 #ifdef __cplusplus
 extern "C"
@@ -21,11 +27,9 @@ extern "C"
 #endif
 
   int waku_store_query(void *ctx,
-                       FFICallBack callback,
-                       void *userData,
-                       const char *jsonQuery,
-                       const char *peerAddr,
-                       int timeoutMs);
+                       LogosDeliveryReplyFn on_reply,
+                       void *user_data,
+                       const WakuStoreQueryReq *req);
 
 #ifdef __cplusplus
 }

--- a/tests/test_delivery_module.cpp
+++ b/tests/test_delivery_module.cpp
@@ -26,7 +26,7 @@ LOGOS_TEST(createNode_succeeds_when_ffi_returns_non_null_context) {
     DeliveryModuleImpl impl;
     LOGOS_ASSERT_TRUE(impl.createNode(R"({"logLevel":"INFO"})").success);
     LOGOS_ASSERT(t.cFunctionCalled("logosdelivery_create_node"));
-    LOGOS_ASSERT(t.cFunctionCalled("logosdelivery_set_event_callback"));
+    LOGOS_ASSERT(t.cFunctionCalled("logosdelivery_add_event_listener"));
 }
 
 LOGOS_TEST(createNode_fails_when_ffi_returns_null) {
@@ -54,7 +54,7 @@ LOGOS_TEST(createNode_succeeds_with_logos_dev_preset_config) {
     DeliveryModuleImpl impl;
     LOGOS_ASSERT_TRUE(impl.createNode(R"({"logLevel":"DEBUG","mode":"Core","preset":"logos.dev"})").success);
     LOGOS_ASSERT(t.cFunctionCalled("logosdelivery_create_node"));
-    LOGOS_ASSERT(t.cFunctionCalled("logosdelivery_set_event_callback"));
+    LOGOS_ASSERT(t.cFunctionCalled("logosdelivery_add_event_listener"));
 }
 
 // start


### PR DESCRIPTION
Bumps the `logos-delivery` flake input from `f8b0365` to `69fbffa` (22 commits, 2026-07-30 → 2026-08-20).

This one is not a lock-only bump. [#4070](https://github.com/logos-messaging/logos-delivery/pull/4070) and [#4082](https://github.com/logos-messaging/logos-delivery/pull/4082) migrated `liblogosdelivery` to the nim-ffi 0.3.0 typed C ABI, which changes every entry point this module calls — the lock bump on its own does not compile.

## What changed upstream

- Argument-taking exports now take a typed request struct and reply through `(errCode, reply, errMsg)` NUL-terminated strings, instead of trailing varargs and a `(callerRet, msg, len)` byte run.
- No-argument exports keep the raw byte-run reply on a "scalar fast path".
- `RET_STALE_WARN` (3) is a new **non-terminal** progress tick: it fires every ~5s on a long call and is always followed by a terminal code.
- `logosdelivery_set_event_callback` is gone. Events are delivered through a per-event listener registry keyed by wire name.
- `logosdelivery_destroy` takes just the context.
- The constructor reports the context as decimal text; the generated header ships `logosdelivery_ctx_create` / `logosdelivery_ctx_destroy` to decode it.

## What changed here

- `api_call_handler.h` binds each call to its request struct and routes replies through one of two trampolines, both of which ignore `RET_STALE_WARN` so a slow call is not completed early. Success takes the reply string, failure the error string.
- Pending calls are keyed by a counter rather than the context's address, so a late reply from a timed-out call cannot wake an unrelated call that reused the address.
- `createNode` goes through `ctx_create` and caches the raw context for calls and event registration; the handle is released with `ctx_destroy`. A context that arrives *after* `createNode` gave up waiting is now destroyed rather than left running unowned.
- The eight events the module forwards are registered by wire name. Payloads still carry the snake_case `eventType`, so the dispatch inside `event_callback` is unchanged.
- The unit-test stub header and mock are updated to the new ABI, including the ctx wrapper the module now relies on.

The module's own Messaging API surface is unchanged — this is entirely below the plugin boundary.

## Verification

- `nix build` of `.#default`, `.#unit-tests` (39 passed), `.#install-portable` and `.#lgx`.
- Because the unit tests run against a mock I wrote from the new header, the ABI's runtime behaviour was also checked against the real library directly: `ctx_create` returns a usable context, all eight listener names are accepted (non-zero ids), `get_node_info` replies `v0.38.1-g69fbff` on the `reply` argument with an empty error, and `ctx_destroy` returns 0.
- The e2e suite in CI is the remaining signal, since it drives the real library through a logoscore daemon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
